### PR TITLE
Add emergency pause and recovery controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/TevaLabs/Xelma-Blockchain/actions/workflows/ci.yml/badge.svg)](https://github.com/TevaLabs/Xelma-Blockchain/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/Rust-1.92.0-orange.svg)](https://www.rust-lang.org/)
 [![Soroban](https://img.shields.io/badge/Soroban-23.0.1-blue.svg)](https://soroban.stellar.org/)
-[![Tests](https://img.shields.io/badge/tests-80%2F80%20passing-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-96%2F96%20passing-brightgreen.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > A trustless, transparent, and decentralized prediction market for XLM price movements built on Stellar blockchain using Soroban smart contracts.
@@ -126,10 +126,11 @@ Unlike traditional prediction markets, Xelma is:
 - **Language**: Rust 1.92.0
 - **Framework**: Soroban SDK 23.0.1
 - **Blockchain**: Stellar (Testnet)
-- **Testing**: 80/80 tests passing (100% coverage)
+- **Testing**: 96/96 tests passing
 
 ### Key Features:
 - ✅ Custom error handling (20 error types)
+- ✅ Emergency pause/recovery controls for incident response
 - ✅ Overflow protection (checked arithmetic)
 - ✅ Role-based access control (Admin, Oracle, User)
 - ✅ Input validation on all functions
@@ -156,6 +157,22 @@ This ensures:
 - ✅ **Zero dust loss** - Every stroops is accounted for
 - ✅ **Simple & predictable** - First predictor gets the remainder
 - ✅ **Fair distribution** - Close to equal split, minimal advantage
+
+### Emergency Pause and Recovery
+
+The contract includes an admin-controlled emergency pause for incidents such as oracle outages or critical bugs.
+
+When paused:
+- Mutating operations are rejected, including round creation, betting, resolution, claims, and token minting.
+- Read-only queries remain available so operators and users can inspect state.
+
+Recovery workflow:
+1. Admin calls `pause_contract()` to freeze high-risk operations.
+2. Investigate and fix the incident off-chain or in a patched deployment.
+3. Admin calls `unpause_contract()` once the system is safe again.
+4. Resume normal round creation and user interaction.
+
+Use `is_paused()` to verify the current contract state before attempting recovery actions.
 
 ### TypeScript Bindings
 - **Language**: TypeScript 5.6.2

--- a/bindings/src/index.ts
+++ b/bindings/src/index.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer";
-import { Address } from "@stellar/stellar-sdk";
+import { Address } from '@stellar/stellar-sdk';
 import {
   AssembledTransaction,
   Client as ContractClient,
@@ -7,7 +7,7 @@ import {
   MethodOptions,
   Result,
   Spec as ContractSpec,
-} from "@stellar/stellar-sdk/contract";
+} from '@stellar/stellar-sdk/contract';
 import type {
   u32,
   i32,
@@ -18,84 +18,20 @@ import type {
   u256,
   i256,
   Option,
-  Timepoint,
+  Typepoint,
   Duration,
-} from "@stellar/stellar-sdk/contract";
-export * from "@stellar/stellar-sdk";
-export * as contract from "@stellar/stellar-sdk/contract";
-export * as rpc from "@stellar/stellar-sdk/rpc";
+} from '@stellar/stellar-sdk/contract';
+export * from '@stellar/stellar-sdk'
+export * as contract from '@stellar/stellar-sdk/contract'
+export * as rpc from '@stellar/stellar-sdk/rpc'
 
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   //@ts-ignore Buffer exists
   window.Buffer = window.Buffer || Buffer;
 }
 
 
 
-
-
-export interface Round {
-  bet_end_ledger: u32;
-  end_ledger: u32;
-  mode: RoundMode;
-  pool_down: i128;
-  pool_up: i128;
-  price_start: u128;
-  round_id: u64;
-  start_ledger: u32;
-}
-
-/**
- * Represents which side a user bet on
- */
-export type BetSide = {tag: "Up", values: void} | {tag: "Down", values: void};
-
-/**
- * Storage keys for contract data
- */
-export type DataKey = {tag: "Balance", values: readonly [string]} | {tag: "Admin", values: void} | {tag: "Oracle", values: void} | {tag: "ActiveRound", values: void} | {tag: "Positions", values: void} | {tag: "UpDownPositions", values: void} | {tag: "PrecisionPositions", values: void} | {tag: "PendingWinnings", values: readonly [string]} | {tag: "UserStats", values: readonly [string]} | {tag: "BetWindowLedgers", values: void} | {tag: "RunWindowLedgers", values: void} | {tag: "LastRoundId", values: void};
-
-/**
- * Round mode for prediction type
- */
-export enum RoundMode {
-  UpDown = 0,
-  Precision = 1,
-}
-
-
-export interface UserStats {
-  best_streak: u32;
-  current_streak: u32;
-  total_losses: u32;
-  total_wins: u32;
-}
-
-
-export interface UserPosition {
-  amount: i128;
-  side: BetSide;
-}
-
-
-export interface OraclePayload {
-  price: u128;
-  /**
- * Round identifier that should match `Round.start_ledger`
- */
-round_id: u32;
-  timestamp: u64;
-}
-
-
-/**
- * Precision prediction entry (user address + predicted price)
- */
-export interface PrecisionPrediction {
-  amount: i128;
-  predicted_price: u128;
-  user: string;
-}
 
 /**
  * Contract error types
@@ -180,37 +116,269 @@ export const ContractError = {
   /**
    * An active round already exists and cannot be overwritten
    */
-  20: {message:"RoundAlreadyActive"}
+  20: {message:"RoundAlreadyActive"},
+  /**
+   * Admin and Oracle addresses cannot be identical
+   */
+  21: {message:"AdminIsOracle"},
+  /**
+   * Contract is paused for emergency recovery
+   */
+  22: {message:"ContractPaused"}
+}
+
+/**
+ * Round mode for prediction type
+ */
+export enum RoundMode {
+  UpDown = 0,
+  Precision = 1,
+}
+
+/**
+ * Storage keys for contract data
+ */
+export type DataKey = {tag: "Balance", values: readonly [string]} | {tag: "Admin", values: void} | {tag: "Oracle", values: void} | {tag: "ActiveRound", values: void} | {tag: "Positions", values: void} | {tag: "UpDownPositions", values: void} | {tag: "PrecisionPositions", values: void} | {tag: "PendingWinnings", values: readonly [string]} | {tag: "UserStats", values: readonly [string]} | {tag: "Paused", values: void} | {tag: "BetWindowLedgers", values: void} | {tag: "RunWindowLedgers", values: void} | {tag: "LastRoundId", values: void};
+
+/**
+ * Represents which side a user bet on
+ */
+export type BetSide = {tag: "Up", values: void} | {tag: "Down", values: void};
+
+
+export interface UserPosition {
+  amount: i128;
+  side: BetSide;
+}
+
+
+export interface UserStats {
+  best_streak: u32;
+  current_streak: u32;
+  total_losses: u32;
+  total_wins: u32;
+}
+
+
+/**
+ * Precision prediction entry (user address + predicted price)
+ */
+export interface PrecisionPrediction {
+  amount: i128;
+  predicted_price: u128;
+  user: string;
+}
+
+
+export interface OraclePayload {
+  price: u128;
+  /**
+ * Round identifier that should match `Round.start_ledger`
+ */
+round_id: u32;
+  timestamp: u64;
+}
+
+
+export interface Round {
+  bet_end_ledger: u32;
+  end_ledger: u32;
+  mode: RoundMode;
+  pool_down: i128;
+  pool_up: i128;
+  price_start: u128;
+  round_id: u64;
+  start_ledger: u32;
 }
 
 export interface Client {
   /**
-   * Construct and simulate a balance transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns user's vXLM balance
+   * Construct and simulate a initialize transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Initializes the contract with admin and oracle addresses (one-time only)
    */
-  balance: ({user}: {user: string}, options?: MethodOptions) => Promise<AssembledTransaction<i128>>
+  initialize: ({admin, oracle}: {admin: string, oracle: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
+
+  /**
+   * Construct and simulate a is_paused transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns whether the contract is currently paused
+   */
+  is_paused: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<boolean>>
+
+  /**
+   * Construct and simulate a pause_contract transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Pauses the contract for emergency recovery (admin only)
+   */
+  pause_contract: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
+
+  /**
+   * Construct and simulate a unpause_contract transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Unpauses the contract after recovery (admin only)
+   */
+  unpause_contract: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
+
+  /**
+   * Construct and simulate a create_round transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Creates a new prediction round (admin only)
+   * mode: 0 = Up/Down (default), 1 = Precision (Legends)
+   */
+  create_round: ({start_price, mode}: {start_price: u128, mode: Option<u32>}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
+
+  /**
+   * Construct and simulate a get_active_round transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns the currently active round, if any
+   */
+  get_active_round: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Option<Round>>>
+
+  /**
+   * Construct and simulate a get_last_round_id transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns the ID of the last created round (0 if no rounds created yet)
+   */
+  get_last_round_id: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<u64>>
 
   /**
    * Construct and simulate a get_admin transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  get_admin: (options?: MethodOptions) => Promise<AssembledTransaction<Option<string>>>
+  get_admin: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
 
-  /**
-   * Construct and simulate a place_bet transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Places a bet on the active round (Up/Down mode only)
-   */
-  place_bet: ({user, amount, side}: {user: string, amount: i128, side: BetSide}, options?: MethodOptions) => Promise<AssembledTransaction<Result<void>>>
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Option<string>>>
 
   /**
    * Construct and simulate a get_oracle transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  get_oracle: (options?: MethodOptions) => Promise<AssembledTransaction<Option<string>>>
+  get_oracle: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
 
-  /**
-   * Construct and simulate a initialize transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Initializes the contract with admin and oracle addresses (one-time only)
-   */
-  initialize: ({admin, oracle}: {admin: string, oracle: string}, options?: MethodOptions) => Promise<AssembledTransaction<Result<void>>>
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Option<string>>>
 
   /**
    * Construct and simulate a set_windows transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
@@ -218,27 +386,213 @@ export interface Client {
    * bet_ledgers: Number of ledgers users can place bets
    * run_ledgers: Total number of ledgers before round can be resolved
    */
-  set_windows: ({bet_ledgers, run_ledgers}: {bet_ledgers: u32, run_ledgers: u32}, options?: MethodOptions) => Promise<AssembledTransaction<Result<void>>>
+  set_windows: ({bet_ledgers, run_ledgers}: {bet_ledgers: u32, run_ledgers: u32}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
 
   /**
-   * Construct and simulate a create_round transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Creates a new prediction round (admin only)
-   * mode: 0 = Up/Down (default), 1 = Precision (Legends)
+   * Construct and simulate a get_user_stats transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns user statistics (wins, losses, streaks)
    */
-  create_round: ({start_price, mode}: {start_price: u128, mode: Option<u32>}, options?: MethodOptions) => Promise<AssembledTransaction<Result<void>>>
+  get_user_stats: ({user}: {user: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<UserStats>>
 
   /**
-   * Construct and simulate a mint_initial transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Mints 1000 vXLM for new users (one-time only)
+   * Construct and simulate a get_pending_winnings transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns user's claimable winnings
    */
-  mint_initial: ({user}: {user: string}, options?: MethodOptions) => Promise<AssembledTransaction<i128>>
+  get_pending_winnings: ({user}: {user: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<i128>>
+
+  /**
+   * Construct and simulate a place_bet transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Places a bet on the active round (Up/Down mode only)
+   */
+  place_bet: ({user, amount, side}: {user: string, amount: i128, side: BetSide}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
+
+  /**
+   * Construct and simulate a place_precision_prediction transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Places a precision prediction on the active round (Precision/Legends mode only)
+   * predicted_price: price scaled to 4 decimals (e.g., 0.2297 → 2297)
+   */
+  place_precision_prediction: ({user, amount, predicted_price}: {user: string, amount: i128, predicted_price: u128}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
 
   /**
    * Construct and simulate a predict_price transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    * Alias for place_precision_prediction - allows users to submit exact price predictions
    * guessed_price: price scaled to 4 decimals (e.g., 0.2297 → 2297)
    */
-  predict_price: ({user, guessed_price, amount}: {user: string, guessed_price: u128, amount: i128}, options?: MethodOptions) => Promise<AssembledTransaction<Result<void>>>
+  predict_price: ({user, guessed_price, amount}: {user: string, guessed_price: u128, amount: i128}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
+
+  /**
+   * Construct and simulate a get_user_position transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns user's position in the current round (Up/Down mode)
+   */
+  get_user_position: ({user}: {user: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Option<UserPosition>>>
+
+  /**
+   * Construct and simulate a get_user_precision_prediction transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns user's precision prediction in the current round (Precision mode)
+   */
+  get_user_precision_prediction: ({user}: {user: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Option<PrecisionPrediction>>>
+
+  /**
+   * Construct and simulate a get_precision_predictions transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns all precision predictions for the current round
+   */
+  get_precision_predictions: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Array<PrecisionPrediction>>>
+
+  /**
+   * Construct and simulate a get_updown_positions transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns all Up/Down positions for the current round
+   */
+  get_updown_positions: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Map<string, UserPosition>>>
 
   /**
    * Construct and simulate a resolve_round transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
@@ -246,68 +600,85 @@ export interface Client {
    * Mode 0 (Up/Down): Winners split losers' pool proportionally; ties get refunds
    * Mode 1 (Precision/Legends): Closest guess wins full pot; ties split evenly
    */
-  resolve_round: ({payload}: {payload: OraclePayload}, options?: MethodOptions) => Promise<AssembledTransaction<Result<void>>>
+  resolve_round: ({payload}: {payload: OraclePayload}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<void>>>
 
   /**
    * Construct and simulate a claim_winnings transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    * Claims pending winnings and adds to balance
    */
-  claim_winnings: ({user}: {user: string}, options?: MethodOptions) => Promise<AssembledTransaction<i128>>
+  claim_winnings: ({user}: {user: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<i128>>>
 
   /**
-   * Construct and simulate a get_user_stats transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns user statistics (wins, losses, streaks)
+   * Construct and simulate a mint_initial transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Mints 1000 vXLM for new users (one-time only)
    */
-  get_user_stats: ({user}: {user: string}, options?: MethodOptions) => Promise<AssembledTransaction<UserStats>>
+  mint_initial: ({user}: {user: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<i128>>
 
   /**
-   * Construct and simulate a get_active_round transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns the currently active round, if any
+   * Construct and simulate a balance transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns user's vXLM balance
    */
-  get_active_round: (options?: MethodOptions) => Promise<AssembledTransaction<Option<Round>>>
+  balance: ({user}: {user: string}, options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
 
-  /**
-   * Construct and simulate a get_last_round_id transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns the ID of the last created round (0 if no rounds created yet)
-   */
-  get_last_round_id: (options?: MethodOptions) => Promise<AssembledTransaction<u64>>
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
 
-  /**
-   * Construct and simulate a get_user_position transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns user's position in the current round (Up/Down mode)
-   */
-  get_user_position: ({user}: {user: string}, options?: MethodOptions) => Promise<AssembledTransaction<Option<UserPosition>>>
-
-  /**
-   * Construct and simulate a get_pending_winnings transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns user's claimable winnings
-   */
-  get_pending_winnings: ({user}: {user: string}, options?: MethodOptions) => Promise<AssembledTransaction<i128>>
-
-  /**
-   * Construct and simulate a get_updown_positions transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns all Up/Down positions for the current round
-   */
-  get_updown_positions: (options?: MethodOptions) => Promise<AssembledTransaction<Map<string, UserPosition>>>
-
-  /**
-   * Construct and simulate a get_precision_predictions transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns all precision predictions for the current round
-   */
-  get_precision_predictions: (options?: MethodOptions) => Promise<AssembledTransaction<Array<PrecisionPrediction>>>
-
-  /**
-   * Construct and simulate a place_precision_prediction transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Places a precision prediction on the active round (Precision/Legends mode only)
-   * predicted_price: price scaled to 4 decimals (e.g., 0.2297 → 2297)
-   */
-  place_precision_prediction: ({user, amount, predicted_price}: {user: string, amount: i128, predicted_price: u128}, options?: MethodOptions) => Promise<AssembledTransaction<Result<void>>>
-
-  /**
-   * Construct and simulate a get_user_precision_prediction transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
-   * Returns user's precision prediction in the current round (Precision mode)
-   */
-  get_user_precision_prediction: ({user}: {user: string}, options?: MethodOptions) => Promise<AssembledTransaction<Option<PrecisionPrediction>>>
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<i128>>
 
 }
 export class Client extends ContractClient {
@@ -327,58 +698,64 @@ export class Client extends ContractClient {
   }
   constructor(public readonly options: ContractClientOptions) {
     super(
-      new ContractSpec([ "AAAAAQAAAAAAAAAAAAAABVJvdW5kAAAAAAAACAAAAAAAAAAOYmV0X2VuZF9sZWRnZXIAAAAAAAQAAAAAAAAACmVuZF9sZWRnZXIAAAAAAAQAAAAAAAAABG1vZGUAAAfQAAAACVJvdW5kTW9kZQAAAAAAAAAAAAAJcG9vbF9kb3duAAAAAAAACwAAAAAAAAAHcG9vbF91cAAAAAALAAAAAAAAAAtwcmljZV9zdGFydAAAAAAKAAAAAAAAAAhyb3VuZF9pZAAAAAYAAAAAAAAADHN0YXJ0X2xlZGdlcgAAAAQ=",
-        "AAAAAgAAACNSZXByZXNlbnRzIHdoaWNoIHNpZGUgYSB1c2VyIGJldCBvbgAAAAAAAAAAB0JldFNpZGUAAAAAAgAAAAAAAAAAAAAAAlVwAAAAAAAAAAAAAAAAAAREb3du",
-        "AAAAAgAAAB5TdG9yYWdlIGtleXMgZm9yIGNvbnRyYWN0IGRhdGEAAAAAAAAAAAAHRGF0YUtleQAAAAAMAAAAAQAAAAAAAAAHQmFsYW5jZQAAAAABAAAAEwAAAAAAAAAAAAAABUFkbWluAAAAAAAAAAAAAAAAAAAGT3JhY2xlAAAAAAAAAAAAAAAAAAtBY3RpdmVSb3VuZAAAAAAAAAAAAAAAAAlQb3NpdGlvbnMAAAAAAAAAAAAAAAAAAA9VcERvd25Qb3NpdGlvbnMAAAAAAAAAAAAAAAASUHJlY2lzaW9uUG9zaXRpb25zAAAAAAABAAAAAAAAAA9QZW5kaW5nV2lubmluZ3MAAAAAAQAAABMAAAABAAAAAAAAAAlVc2VyU3RhdHMAAAAAAAABAAAAEwAAAAAAAAAAAAAAEEJldFdpbmRvd0xlZGdlcnMAAAAAAAAAAAAAABBSdW5XaW5kb3dMZWRnZXJzAAAAAAAAAAAAAAALTGFzdFJvdW5kSWQA",
-        "AAAAAwAAAB5Sb3VuZCBtb2RlIGZvciBwcmVkaWN0aW9uIHR5cGUAAAAAAAAAAAAJUm91bmRNb2RlAAAAAAAAAgAAAAAAAAAGVXBEb3duAAAAAAAAAAAAAAAAAAlQcmVjaXNpb24AAAAAAAAB",
-        "AAAAAQAAAAAAAAAAAAAACVVzZXJTdGF0cwAAAAAAAAQAAAAAAAAAC2Jlc3Rfc3RyZWFrAAAAAAQAAAAAAAAADmN1cnJlbnRfc3RyZWFrAAAAAAAEAAAAAAAAAAx0b3RhbF9sb3NzZXMAAAAEAAAAAAAAAAp0b3RhbF93aW5zAAAAAAAE",
-        "AAAAAQAAAAAAAAAAAAAADFVzZXJQb3NpdGlvbgAAAAIAAAAAAAAABmFtb3VudAAAAAAACwAAAAAAAAAEc2lkZQAAB9AAAAAHQmV0U2lkZQA=",
-        "AAAAAQAAAAAAAAAAAAAADU9yYWNsZVBheWxvYWQAAAAAAAADAAAAAAAAAAVwcmljZQAAAAAAAAoAAAA3Um91bmQgaWRlbnRpZmllciB0aGF0IHNob3VsZCBtYXRjaCBgUm91bmQuc3RhcnRfbGVkZ2VyYAAAAAAIcm91bmRfaWQAAAAEAAAAAAAAAAl0aW1lc3RhbXAAAAAAAAAG",
-        "AAAAAQAAADtQcmVjaXNpb24gcHJlZGljdGlvbiBlbnRyeSAodXNlciBhZGRyZXNzICsgcHJlZGljdGVkIHByaWNlKQAAAAAAAAAAE1ByZWNpc2lvblByZWRpY3Rpb24AAAAAAwAAAAAAAAAGYW1vdW50AAAAAAALAAAAAAAAAA9wcmVkaWN0ZWRfcHJpY2UAAAAACgAAAAAAAAAEdXNlcgAAABM=",
-        "AAAABAAAABRDb250cmFjdCBlcnJvciB0eXBlcwAAAAAAAAANQ29udHJhY3RFcnJvcgAAAAAAABQAAAAlQ29udHJhY3QgaGFzIGFscmVhZHkgYmVlbiBpbml0aWFsaXplZAAAAAAAABJBbHJlYWR5SW5pdGlhbGl6ZWQAAAAAAAEAAAAtQWRtaW4gYWRkcmVzcyBub3Qgc2V0IC0gY2FsbCBpbml0aWFsaXplIGZpcnN0AAAAAAAAC0FkbWluTm90U2V0AAAAAAIAAAAuT3JhY2xlIGFkZHJlc3Mgbm90IHNldCAtIGNhbGwgaW5pdGlhbGl6ZSBmaXJzdAAAAAAADE9yYWNsZU5vdFNldAAAAAMAAAAiT25seSBhZG1pbiBjYW4gcGVyZm9ybSB0aGlzIGFjdGlvbgAAAAAAEVVuYXV0aG9yaXplZEFkbWluAAAAAAAABAAAACNPbmx5IG9yYWNsZSBjYW4gcGVyZm9ybSB0aGlzIGFjdGlvbgAAAAASVW5hdXRob3JpemVkT3JhY2xlAAAAAAAFAAAAJEJldCBhbW91bnQgbXVzdCBiZSBncmVhdGVyIHRoYW4gemVybwAAABBJbnZhbGlkQmV0QW1vdW50AAAABgAAABZObyBhY3RpdmUgcm91bmQgZXhpc3RzAAAAAAANTm9BY3RpdmVSb3VuZAAAAAAAAAcAAAAXUm91bmQgaGFzIGFscmVhZHkgZW5kZWQAAAAAClJvdW5kRW5kZWQAAAAAAAgAAAAdVXNlciBoYXMgaW5zdWZmaWNpZW50IGJhbGFuY2UAAAAAAAATSW5zdWZmaWNpZW50QmFsYW5jZQAAAAAJAAAAK1VzZXIgaGFzIGFscmVhZHkgcGxhY2VkIGEgYmV0IGluIHRoaXMgcm91bmQAAAAACkFscmVhZHlCZXQAAAAAAAoAAAAcQXJpdGhtZXRpYyBvdmVyZmxvdyBvY2N1cnJlZAAAAAhPdmVyZmxvdwAAAAsAAAATSW52YWxpZCBwcmljZSB2YWx1ZQAAAAAMSW52YWxpZFByaWNlAAAADAAAABZJbnZhbGlkIGR1cmF0aW9uIHZhbHVlAAAAAAAPSW52YWxpZER1cmF0aW9uAAAAAA0AAAAjSW52YWxpZCByb3VuZCBtb2RlIChtdXN0IGJlIDAgb3IgMSkAAAAAC0ludmFsaWRNb2RlAAAAAA4AAAAsV3JvbmcgcHJlZGljdGlvbiB0eXBlIGZvciBjdXJyZW50IHJvdW5kIG1vZGUAAAAWV3JvbmdNb2RlRm9yUHJlZGljdGlvbgAAAAAADwAAACRSb3VuZCBoYXMgbm90IHJlYWNoZWQgZW5kX2xlZGdlciB5ZXQAAAANUm91bmROb3RFbmRlZAAAAAAAABAAAAA1SW52YWxpZCBwcmljZSBzY2FsZSAobXVzdCByZXByZXNlbnQgNCBkZWNpbWFsIHBsYWNlcykAAAAAAAARSW52YWxpZFByaWNlU2NhbGUAAAAAAAARAAAAHk9yYWNsZSBkYXRhIGlzIHRvbyBvbGQgKFNUQUxFKQAAAAAAD1N0YWxlT3JhY2xlRGF0YQAAAAASAAAAMU9yYWNsZSBwYXlsb2FkIHJvdW5kX2lkIGRvZXNuJ3QgbWF0Y2ggQWN0aXZlUm91bmQAAAAAAAASSW52YWxpZE9yYWNsZVJvdW5kAAAAAAATAAAAOEFuIGFjdGl2ZSByb3VuZCBhbHJlYWR5IGV4aXN0cyBhbmQgY2Fubm90IGJlIG92ZXJ3cml0dGVuAAAAElJvdW5kQWxyZWFkeUFjdGl2ZQAAAAAAFA==",
-        "AAAAAAAAABtSZXR1cm5zIHVzZXIncyB2WExNIGJhbGFuY2UAAAAAB2JhbGFuY2UAAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAACw==",
-        "AAAAAAAAAAAAAAAJZ2V0X2FkbWluAAAAAAAAAAAAAAEAAAPoAAAAEw==",
-        "AAAAAAAAADRQbGFjZXMgYSBiZXQgb24gdGhlIGFjdGl2ZSByb3VuZCAoVXAvRG93biBtb2RlIG9ubHkpAAAACXBsYWNlX2JldAAAAAAAAAMAAAAAAAAABHVzZXIAAAATAAAAAAAAAAZhbW91bnQAAAAAAAsAAAAAAAAABHNpZGUAAAfQAAAAB0JldFNpZGUAAAAAAQAAA+kAAAPtAAAAAAAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
-        "AAAAAAAAAAAAAAAKZ2V0X29yYWNsZQAAAAAAAAAAAAEAAAPoAAAAEw==",
-        "AAAAAAAAAEhJbml0aWFsaXplcyB0aGUgY29udHJhY3Qgd2l0aCBhZG1pbiBhbmQgb3JhY2xlIGFkZHJlc3NlcyAob25lLXRpbWUgb25seSkAAAAKaW5pdGlhbGl6ZQAAAAAAAgAAAAAAAAAFYWRtaW4AAAAAAAATAAAAAAAAAAZvcmFjbGUAAAAAABMAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
-        "AAAAAAAAAKlTZXRzIHRoZSBiZXR0aW5nIGFuZCBleGVjdXRpb24gd2luZG93cyAoYWRtaW4gb25seSkKYmV0X2xlZGdlcnM6IE51bWJlciBvZiBsZWRnZXJzIHVzZXJzIGNhbiBwbGFjZSBiZXRzCnJ1bl9sZWRnZXJzOiBUb3RhbCBudW1iZXIgb2YgbGVkZ2VycyBiZWZvcmUgcm91bmQgY2FuIGJlIHJlc29sdmVkAAAAAAAAC3NldF93aW5kb3dzAAAAAAIAAAAAAAAAC2JldF9sZWRnZXJzAAAAAAQAAAAAAAAAC3J1bl9sZWRnZXJzAAAAAAQAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+      new ContractSpec([ "AAAAAAAAAEhJbml0aWFsaXplcyB0aGUgY29udHJhY3Qgd2l0aCBhZG1pbiBhbmQgb3JhY2xlIGFkZHJlc3NlcyAob25lLXRpbWUgb25seSkAAAAKaW5pdGlhbGl6ZQAAAAAAAgAAAAAAAAAFYWRtaW4AAAAAAAATAAAAAAAAAAZvcmFjbGUAAAAAABMAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAADBSZXR1cm5zIHdoZXRoZXIgdGhlIGNvbnRyYWN0IGlzIGN1cnJlbnRseSBwYXVzZWQAAAAJaXNfcGF1c2VkAAAAAAAAAAAAAAEAAAAB",
+        "AAAAAAAAADdQYXVzZXMgdGhlIGNvbnRyYWN0IGZvciBlbWVyZ2VuY3kgcmVjb3ZlcnkgKGFkbWluIG9ubHkpAAAAAA5wYXVzZV9jb250cmFjdAAAAAAAAAAAAAEAAAPpAAAD7QAAAAAAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAADFVbnBhdXNlcyB0aGUgY29udHJhY3QgYWZ0ZXIgcmVjb3ZlcnkgKGFkbWluIG9ubHkpAAAAAAAAEHVucGF1c2VfY29udHJhY3QAAAAAAAAAAQAAA+kAAAPtAAAAAAAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
         "AAAAAAAAAGBDcmVhdGVzIGEgbmV3IHByZWRpY3Rpb24gcm91bmQgKGFkbWluIG9ubHkpCm1vZGU6IDAgPSBVcC9Eb3duIChkZWZhdWx0KSwgMSA9IFByZWNpc2lvbiAoTGVnZW5kcykAAAAMY3JlYXRlX3JvdW5kAAAAAgAAAAAAAAALc3RhcnRfcHJpY2UAAAAACgAAAAAAAAAEbW9kZQAAA+gAAAAEAAAAAQAAA+kAAAPtAAAAAAAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
-        "AAAAAAAAAC1NaW50cyAxMDAwIHZYTE0gZm9yIG5ldyB1c2VycyAob25lLXRpbWUgb25seSkAAAAAAAAMbWludF9pbml0aWFsAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAACw==",
-        "AAAAAAAAAJdBbGlhcyBmb3IgcGxhY2VfcHJlY2lzaW9uX3ByZWRpY3Rpb24gLSBhbGxvd3MgdXNlcnMgdG8gc3VibWl0IGV4YWN0IHByaWNlIHByZWRpY3Rpb25zCmd1ZXNzZWRfcHJpY2U6IHByaWNlIHNjYWxlZCB0byA0IGRlY2ltYWxzIChlLmcuLCAwLjIyOTcg4oaSIDIyOTcpAAAAAA1wcmVkaWN0X3ByaWNlAAAAAAAAAwAAAAAAAAAEdXNlcgAAABMAAAAAAAAADWd1ZXNzZWRfcHJpY2UAAAAAAAAKAAAAAAAAAAZhbW91bnQAAAAAAAsAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
-        "AAAAAAAAAM1SZXNvbHZlcyB0aGUgcm91bmQgd2l0aCBvcmFjbGUgcGF5bG9hZCAob3JhY2xlIG9ubHkpCk1vZGUgMCAoVXAvRG93bik6IFdpbm5lcnMgc3BsaXQgbG9zZXJzJyBwb29sIHByb3BvcnRpb25hbGx5OyB0aWVzIGdldCByZWZ1bmRzCk1vZGUgMSAoUHJlY2lzaW9uL0xlZ2VuZHMpOiBDbG9zZXN0IGd1ZXNzIHdpbnMgZnVsbCBwb3Q7IHRpZXMgc3BsaXQgZXZlbmx5AAAAAAAADXJlc29sdmVfcm91bmQAAAAAAAABAAAAAAAAAAdwYXlsb2FkAAAAB9AAAAANT3JhY2xlUGF5bG9hZAAAAAAAAAEAAAPpAAAD7QAAAAAAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
-        "AAAAAAAAACtDbGFpbXMgcGVuZGluZyB3aW5uaW5ncyBhbmQgYWRkcyB0byBiYWxhbmNlAAAAAA5jbGFpbV93aW5uaW5ncwAAAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAACw==",
-        "AAAAAAAAAC9SZXR1cm5zIHVzZXIgc3RhdGlzdGljcyAod2lucywgbG9zc2VzLCBzdHJlYWtzKQAAAAAOZ2V0X3VzZXJfc3RhdHMAAAAAAAEAAAAAAAAABHVzZXIAAAATAAAAAQAAB9AAAAAJVXNlclN0YXRzAAAA",
         "AAAAAAAAACpSZXR1cm5zIHRoZSBjdXJyZW50bHkgYWN0aXZlIHJvdW5kLCBpZiBhbnkAAAAAABBnZXRfYWN0aXZlX3JvdW5kAAAAAAAAAAEAAAPoAAAH0AAAAAVSb3VuZAAAAA==",
         "AAAAAAAAAEVSZXR1cm5zIHRoZSBJRCBvZiB0aGUgbGFzdCBjcmVhdGVkIHJvdW5kICgwIGlmIG5vIHJvdW5kcyBjcmVhdGVkIHlldCkAAAAAAAARZ2V0X2xhc3Rfcm91bmRfaWQAAAAAAAAAAAAAAQAAAAY=",
-        "AAAAAAAAADtSZXR1cm5zIHVzZXIncyBwb3NpdGlvbiBpbiB0aGUgY3VycmVudCByb3VuZCAoVXAvRG93biBtb2RlKQAAAAARZ2V0X3VzZXJfcG9zaXRpb24AAAAAAAABAAAAAAAAAAR1c2VyAAAAEwAAAAEAAAPoAAAH0AAAAAxVc2VyUG9zaXRpb24=",
+        "AAAAAAAAAAAAAAAJZ2V0X2FkbWluAAAAAAAAAAAAAAEAAAPoAAAAEw==",
+        "AAAAAAAAAAAAAAAKZ2V0X29yYWNsZQAAAAAAAAAAAAEAAAPoAAAAEw==",
+        "AAAAAAAAAKlTZXRzIHRoZSBiZXR0aW5nIGFuZCBleGVjdXRpb24gd2luZG93cyAoYWRtaW4gb25seSkKYmV0X2xlZGdlcnM6IE51bWJlciBvZiBsZWRnZXJzIHVzZXJzIGNhbiBwbGFjZSBiZXRzCnJ1bl9sZWRnZXJzOiBUb3RhbCBudW1iZXIgb2YgbGVkZ2VycyBiZWZvcmUgcm91bmQgY2FuIGJlIHJlc29sdmVkAAAAAAAAC3NldF93aW5kb3dzAAAAAAIAAAAAAAAAC2JldF9sZWRnZXJzAAAAAAQAAAAAAAAAC3J1bl9sZWRnZXJzAAAAAAQAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAAC9SZXR1cm5zIHVzZXIgc3RhdGlzdGljcyAod2lucywgbG9zc2VzLCBzdHJlYWtzKQAAAAAOZ2V0X3VzZXJfc3RhdHMAAAAAAAEAAAAAAAAABHVzZXIAAAATAAAAAQAAB9AAAAAJVXNlclN0YXRzAAAA",
         "AAAAAAAAACFSZXR1cm5zIHVzZXIncyBjbGFpbWFibGUgd2lubmluZ3MAAAAAAAAUZ2V0X3BlbmRpbmdfd2lubmluZ3MAAAABAAAAAAAAAAR1c2VyAAAAEwAAAAEAAAAL",
-        "AAAAAAAAADNSZXR1cm5zIGFsbCBVcC9Eb3duIHBvc2l0aW9ucyBmb3IgdGhlIGN1cnJlbnQgcm91bmQAAAAAFGdldF91cGRvd25fcG9zaXRpb25zAAAAAAAAAAEAAAPsAAAAEwAAB9AAAAAMVXNlclBvc2l0aW9u",
-        "AAAAAAAAADdSZXR1cm5zIGFsbCBwcmVjaXNpb24gcHJlZGljdGlvbnMgZm9yIHRoZSBjdXJyZW50IHJvdW5kAAAAABlnZXRfcHJlY2lzaW9uX3ByZWRpY3Rpb25zAAAAAAAAAAAAAAEAAAPqAAAH0AAAABNQcmVjaXNpb25QcmVkaWN0aW9uAA==",
+        "AAAAAAAAADRQbGFjZXMgYSBiZXQgb24gdGhlIGFjdGl2ZSByb3VuZCAoVXAvRG93biBtb2RlIG9ubHkpAAAACXBsYWNlX2JldAAAAAAAAAMAAAAAAAAABHVzZXIAAAATAAAAAAAAAAZhbW91bnQAAAAAAAsAAAAAAAAABHNpZGUAAAfQAAAAB0JldFNpZGUAAAAAAQAAA+kAAAPtAAAAAAAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
         "AAAAAAAAAJNQbGFjZXMgYSBwcmVjaXNpb24gcHJlZGljdGlvbiBvbiB0aGUgYWN0aXZlIHJvdW5kIChQcmVjaXNpb24vTGVnZW5kcyBtb2RlIG9ubHkpCnByZWRpY3RlZF9wcmljZTogcHJpY2Ugc2NhbGVkIHRvIDQgZGVjaW1hbHMgKGUuZy4sIDAuMjI5NyDihpIgMjI5NykAAAAAGnBsYWNlX3ByZWNpc2lvbl9wcmVkaWN0aW9uAAAAAAADAAAAAAAAAAR1c2VyAAAAEwAAAAAAAAAGYW1vdW50AAAAAAALAAAAAAAAAA9wcmVkaWN0ZWRfcHJpY2UAAAAACgAAAAEAAAPpAAAD7QAAAAAAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
-        "AAAAAAAAAElSZXR1cm5zIHVzZXIncyBwcmVjaXNpb24gcHJlZGljdGlvbiBpbiB0aGUgY3VycmVudCByb3VuZCAoUHJlY2lzaW9uIG1vZGUpAAAAAAAAHWdldF91c2VyX3ByZWNpc2lvbl9wcmVkaWN0aW9uAAAAAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAD6AAAB9AAAAATUHJlY2lzaW9uUHJlZGljdGlvbgA=" ]),
+        "AAAAAAAAAJdBbGlhcyBmb3IgcGxhY2VfcHJlY2lzaW9uX3ByZWRpY3Rpb24gLSBhbGxvd3MgdXNlcnMgdG8gc3VibWl0IGV4YWN0IHByaWNlIHByZWRpY3Rpb25zCmd1ZXNzZWRfcHJpY2U6IHByaWNlIHNjYWxlZCB0byA0IGRlY2ltYWxzIChlLmcuLCAwLjIyOTcg4oaSIDIyOTcpAAAAAA1wcmVkaWN0X3ByaWNlAAAAAAAAAwAAAAAAAAAEdXNlcgAAABMAAAAAAAAADWd1ZXNzZWRfcHJpY2UAAAAAAAAKAAAAAAAAAAZhbW91bnQAAAAAAAsAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAADtSZXR1cm5zIHVzZXIncyBwb3NpdGlvbiBpbiB0aGUgY3VycmVudCByb3VuZCAoVXAvRG93biBtb2RlKQAAAAARZ2V0X3VzZXJfcG9zaXRpb24AAAAAAAABAAAAAAAAAAR1c2VyAAAAEwAAAAEAAAPoAAAH0AAAAAxVc2VyUG9zaXRpb24=",
+        "AAAAAAAAAElSZXR1cm5zIHVzZXIncyBwcmVjaXNpb24gcHJlZGljdGlvbiBpbiB0aGUgY3VycmVudCByb3VuZCAoUHJlY2lzaW9uIG1vZGUpAAAAAAAAHWdldF91c2VyX3ByZWNpc2lvbl9wcmVkaWN0aW9uAAAAAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAD6AAAB9AAAAATUHJlY2lzaW9uUHJlZGljdGlvbgA=",
+        "AAAAAAAAADdSZXR1cm5zIGFsbCBwcmVjaXNpb24gcHJlZGljdGlvbnMgZm9yIHRoZSBjdXJyZW50IHJvdW5kAAAAABlnZXRfcHJlY2lzaW9uX3ByZWRpY3Rpb25zAAAAAAAAAAAAAAEAAAPqAAAH0AAAABNQcmVjaXNpb25QcmVkaWN0aW9uAA==",
+        "AAAAAAAAADNSZXR1cm5zIGFsbCBVcC9Eb3duIHBvc2l0aW9ucyBmb3IgdGhlIGN1cnJlbnQgcm91bmQAAAAAFGdldF91cGRvd25fcG9zaXRpb25zAAAAAAAAAAEAAAPsAAAAEwAAB9AAAAAMVXNlclBvc2l0aW9u",
+        "AAAAAAAAAM1SZXNvbHZlcyB0aGUgcm91bmQgd2l0aCBvcmFjbGUgcGF5bG9hZCAob3JhY2xlIG9ubHkpCk1vZGUgMCAoVXAvRG93bik6IFdpbm5lcnMgc3BsaXQgbG9zZXJzJyBwb29sIHByb3BvcnRpb25hbGx5OyB0aWVzIGdldCByZWZ1bmRzCk1vZGUgMSAoUHJlY2lzaW9uL0xlZ2VuZHMpOiBDbG9zZXN0IGd1ZXNzIHdpbnMgZnVsbCBwb3Q7IHRpZXMgc3BsaXQgZXZlbmx5AAAAAAAADXJlc29sdmVfcm91bmQAAAAAAAABAAAAAAAAAAdwYXlsb2FkAAAAB9AAAAANT3JhY2xlUGF5bG9hZAAAAAAAAAEAAAPpAAAD7QAAAAAAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAACtDbGFpbXMgcGVuZGluZyB3aW5uaW5ncyBhbmQgYWRkcyB0byBiYWxhbmNlAAAAAA5jbGFpbV93aW5uaW5ncwAAAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAD6QAAAAsAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAAC1NaW50cyAxMDAwIHZYTE0gZm9yIG5ldyB1c2VycyAob25lLXRpbWUgb25seSkAAAAAAAAMbWludF9pbml0aWFsAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAACw==",
+        "AAAAAAAAABtSZXR1cm5zIHVzZXIncyB2WExNIGJhbGFuY2UAAAAAB2JhbGFuY2UAAAAAAQAAAAAAAAAEdXNlcgAAABMAAAABAAAACw==",
+        "AAAABAAAABRDb250cmFjdCBlcnJvciB0eXBlcwAAAAAAAAANQ29udHJhY3RFcnJvcgAAAAAAABYAAAAlQ29udHJhY3QgaGFzIGFscmVhZHkgYmVlbiBpbml0aWFsaXplZAAAAAAAABJBbHJlYWR5SW5pdGlhbGl6ZWQAAAAAAAEAAAAtQWRtaW4gYWRkcmVzcyBub3Qgc2V0IC0gY2FsbCBpbml0aWFsaXplIGZpcnN0AAAAAAAAC0FkbWluTm90U2V0AAAAAAIAAAAuT3JhY2xlIGFkZHJlc3Mgbm90IHNldCAtIGNhbGwgaW5pdGlhbGl6ZSBmaXJzdAAAAAAADE9yYWNsZU5vdFNldAAAAAMAAAAiT25seSBhZG1pbiBjYW4gcGVyZm9ybSB0aGlzIGFjdGlvbgAAAAAAEVVuYXV0aG9yaXplZEFkbWluAAAAAAAABAAAACNPbmx5IG9yYWNsZSBjYW4gcGVyZm9ybSB0aGlzIGFjdGlvbgAAAAASVW5hdXRob3JpemVkT3JhY2xlAAAAAAAFAAAAJEJldCBhbW91bnQgbXVzdCBiZSBncmVhdGVyIHRoYW4gemVybwAAABBJbnZhbGlkQmV0QW1vdW50AAAABgAAABZObyBhY3RpdmUgcm91bmQgZXhpc3RzAAAAAAANTm9BY3RpdmVSb3VuZAAAAAAAAAcAAAAXUm91bmQgaGFzIGFscmVhZHkgZW5kZWQAAAAAClJvdW5kRW5kZWQAAAAAAAgAAAAdVXNlciBoYXMgaW5zdWZmaWNpZW50IGJhbGFuY2UAAAAAAAATSW5zdWZmaWNpZW50QmFsYW5jZQAAAAAJAAAAK1VzZXIgaGFzIGFscmVhZHkgcGxhY2VkIGEgYmV0IGluIHRoaXMgcm91bmQAAAAACkFscmVhZHlCZXQAAAAAAAoAAAAcQXJpdGhtZXRpYyBvdmVyZmxvdyBvY2N1cnJlZAAAAAhPdmVyZmxvdwAAAAsAAAATSW52YWxpZCBwcmljZSB2YWx1ZQAAAAAMSW52YWxpZFByaWNlAAAADAAAABZJbnZhbGlkIGR1cmF0aW9uIHZhbHVlAAAAAAAPSW52YWxpZER1cmF0aW9uAAAAAA0AAAAjSW52YWxpZCByb3VuZCBtb2RlIChtdXN0IGJlIDAgb3IgMSkAAAAAC0ludmFsaWRNb2RlAAAAAA4AAAAsV3JvbmcgcHJlZGljdGlvbiB0eXBlIGZvciBjdXJyZW50IHJvdW5kIG1vZGUAAAAWV3JvbmdNb2RlRm9yUHJlZGljdGlvbgAAAAAADwAAACRSb3VuZCBoYXMgbm90IHJlYWNoZWQgZW5kX2xlZGdlciB5ZXQAAAANUm91bmROb3RFbmRlZAAAAAAAABAAAAA1SW52YWxpZCBwcmljZSBzY2FsZSAobXVzdCByZXByZXNlbnQgNCBkZWNpbWFsIHBsYWNlcykAAAAAAAARSW52YWxpZFByaWNlU2NhbGUAAAAAAAARAAAAHk9yYWNsZSBkYXRhIGlzIHRvbyBvbGQgKFNUQUxFKQAAAAAAD1N0YWxlT3JhY2xlRGF0YQAAAAASAAAAMU9yYWNsZSBwYXlsb2FkIHJvdW5kX2lkIGRvZXNuJ3QgbWF0Y2ggQWN0aXZlUm91bmQAAAAAAAASSW52YWxpZE9yYWNsZVJvdW5kAAAAAAATAAAAOEFuIGFjdGl2ZSByb3VuZCBhbHJlYWR5IGV4aXN0cyBhbmQgY2Fubm90IGJlIG92ZXJ3cml0dGVuAAAAElJvdW5kQWxyZWFkeUFjdGl2ZQAAAAAAFAAAAC5BZG1pbiBhbmQgT3JhY2xlIGFkZHJlc3NlcyBjYW5ub3QgYmUgaWRlbnRpY2FsAAAAAAANQWRtaW5Jc09yYWNsZQAAAAAAABUAAAApQ29udHJhY3QgaXMgcGF1c2VkIGZvciBlbWVyZ2VuY3kgcmVjb3ZlcnkAAAAAAAAOQ29udHJhY3RQYXVzZWQAAAAAABY=",
+        "AAAAAwAAAB5Sb3VuZCBtb2RlIGZvciBwcmVkaWN0aW9uIHR5cGUAAAAAAAAAAAAJUm91bmRNb2RlAAAAAAAAAgAAAAAAAAAGVXBEb3duAAAAAAAAAAAAAAAAAAlQcmVjaXNpb24AAAAAAAAB",
+        "AAAAAgAAAB5TdG9yYWdlIGtleXMgZm9yIGNvbnRyYWN0IGRhdGEAAAAAAAAAAAAHRGF0YUtleQAAAAANAAAAAQAAAAAAAAAHQmFsYW5jZQAAAAABAAAAEwAAAAAAAAAAAAAABUFkbWluAAAAAAAAAAAAAAAAAAAGT3JhY2xlAAAAAAAAAAAAAAAAAAtBY3RpdmVSb3VuZAAAAAAAAAAAAAAAAAlQb3NpdGlvbnMAAAAAAAAAAAAAAAAAAA9VcERvd25Qb3NpdGlvbnMAAAAAAAAAAAAAAAASUHJlY2lzaW9uUG9zaXRpb25zAAAAAAABAAAAAAAAAA9QZW5kaW5nV2lubmluZ3MAAAAAAQAAABMAAAABAAAAAAAAAAlVc2VyU3RhdHMAAAAAAAABAAAAEwAAAAAAAAAAAAAABlBhdXNlZAAAAAAAAAAAAAAAAAAQQmV0V2luZG93TGVkZ2VycwAAAAAAAAAAAAAAEFJ1bldpbmRvd0xlZGdlcnMAAAAAAAAAAAAAAAtMYXN0Um91bmRJZAA=",
+        "AAAAAgAAACNSZXByZXNlbnRzIHdoaWNoIHNpZGUgYSB1c2VyIGJldCBvbgAAAAAAAAAAB0JldFNpZGUAAAAAAgAAAAAAAAAAAAAAAlVwAAAAAAAAAAAAAAAAAAREb3du",
+        "AAAAAQAAAAAAAAAAAAAADFVzZXJQb3NpdGlvbgAAAAIAAAAAAAAABmFtb3VudAAAAAAACwAAAAAAAAAEc2lkZQAAB9AAAAAHQmV0U2lkZQA=",
+        "AAAAAQAAAAAAAAAAAAAACVVzZXJTdGF0cwAAAAAAAAQAAAAAAAAAC2Jlc3Rfc3RyZWFrAAAAAAQAAAAAAAAADmN1cnJlbnRfc3RyZWFrAAAAAAAEAAAAAAAAAAx0b3RhbF9sb3NzZXMAAAAEAAAAAAAAAAp0b3RhbF93aW5zAAAAAAAE",
+        "AAAAAQAAADtQcmVjaXNpb24gcHJlZGljdGlvbiBlbnRyeSAodXNlciBhZGRyZXNzICsgcHJlZGljdGVkIHByaWNlKQAAAAAAAAAAE1ByZWNpc2lvblByZWRpY3Rpb24AAAAAAwAAAAAAAAAGYW1vdW50AAAAAAALAAAAAAAAAA9wcmVkaWN0ZWRfcHJpY2UAAAAACgAAAAAAAAAEdXNlcgAAABM=",
+        "AAAAAQAAAAAAAAAAAAAADU9yYWNsZVBheWxvYWQAAAAAAAADAAAAAAAAAAVwcmljZQAAAAAAAAoAAAA3Um91bmQgaWRlbnRpZmllciB0aGF0IHNob3VsZCBtYXRjaCBgUm91bmQuc3RhcnRfbGVkZ2VyYAAAAAAIcm91bmRfaWQAAAAEAAAAAAAAAAl0aW1lc3RhbXAAAAAAAAAG",
+        "AAAAAQAAAAAAAAAAAAAABVJvdW5kAAAAAAAACAAAAAAAAAAOYmV0X2VuZF9sZWRnZXIAAAAAAAQAAAAAAAAACmVuZF9sZWRnZXIAAAAAAAQAAAAAAAAABG1vZGUAAAfQAAAACVJvdW5kTW9kZQAAAAAAAAAAAAAJcG9vbF9kb3duAAAAAAAACwAAAAAAAAAHcG9vbF91cAAAAAALAAAAAAAAAAtwcmljZV9zdGFydAAAAAAKAAAAAAAAAAhyb3VuZF9pZAAAAAYAAAAAAAAADHN0YXJ0X2xlZGdlcgAAAAQ=" ]),
       options
     )
   }
   public readonly fromJSON = {
-    balance: this.txFromJSON<i128>,
-        get_admin: this.txFromJSON<Option<string>>,
-        place_bet: this.txFromJSON<Result<void>>,
-        get_oracle: this.txFromJSON<Option<string>>,
-        initialize: this.txFromJSON<Result<void>>,
-        set_windows: this.txFromJSON<Result<void>>,
+    initialize: this.txFromJSON<Result<void>>,
+        is_paused: this.txFromJSON<boolean>,
+        pause_contract: this.txFromJSON<Result<void>>,
+        unpause_contract: this.txFromJSON<Result<void>>,
         create_round: this.txFromJSON<Result<void>>,
-        mint_initial: this.txFromJSON<i128>,
-        predict_price: this.txFromJSON<Result<void>>,
-        resolve_round: this.txFromJSON<Result<void>>,
-        claim_winnings: this.txFromJSON<i128>,
-        get_user_stats: this.txFromJSON<UserStats>,
         get_active_round: this.txFromJSON<Option<Round>>,
         get_last_round_id: this.txFromJSON<u64>,
-        get_user_position: this.txFromJSON<Option<UserPosition>>,
+        get_admin: this.txFromJSON<Option<string>>,
+        get_oracle: this.txFromJSON<Option<string>>,
+        set_windows: this.txFromJSON<Result<void>>,
+        get_user_stats: this.txFromJSON<UserStats>,
         get_pending_winnings: this.txFromJSON<i128>,
-        get_updown_positions: this.txFromJSON<Map<string, UserPosition>>,
-        get_precision_predictions: this.txFromJSON<Array<PrecisionPrediction>>,
+        place_bet: this.txFromJSON<Result<void>>,
         place_precision_prediction: this.txFromJSON<Result<void>>,
-        get_user_precision_prediction: this.txFromJSON<Option<PrecisionPrediction>>
+        predict_price: this.txFromJSON<Result<void>>,
+        get_user_position: this.txFromJSON<Option<UserPosition>>,
+        get_user_precision_prediction: this.txFromJSON<Option<PrecisionPrediction>>,
+        get_precision_predictions: this.txFromJSON<Array<PrecisionPrediction>>,
+        get_updown_positions: this.txFromJSON<Map<string, UserPosition>>,
+        resolve_round: this.txFromJSON<Result<void>>,
+        claim_winnings: this.txFromJSON<Result<i128>>,
+        mint_initial: this.txFromJSON<i128>,
+        balance: this.txFromJSON<i128>
   }
 }

--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -1,6 +1,6 @@
 //! Core contract implementation for the XLM Price Prediction Market.
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Vec};
+use soroban_sdk::{contract, contractimpl, panic_with_error, symbol_short, Address, Env, Map, Vec};
 
 use crate::errors::ContractError;
 use crate::types::{
@@ -26,6 +26,7 @@ impl VirtualTokenContract {
 
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::Oracle, &oracle);
+        env.storage().persistent().set(&DataKey::Paused, &false);
 
         // Set default window values
         env.storage()
@@ -34,6 +35,42 @@ impl VirtualTokenContract {
         env.storage()
             .persistent()
             .set(&DataKey::RunWindowLedgers, &12u32);
+
+        Ok(())
+    }
+
+    /// Returns whether the contract is currently paused
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    /// Pauses the contract for emergency recovery (admin only)
+    pub fn pause_contract(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::AdminNotSet)?;
+
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &true);
+
+        Ok(())
+    }
+
+    /// Unpauses the contract after recovery (admin only)
+    pub fn unpause_contract(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::AdminNotSet)?;
+
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &false);
 
         Ok(())
     }
@@ -70,6 +107,7 @@ impl VirtualTokenContract {
             .ok_or(ContractError::AdminNotSet)?;
 
         admin.require_auth();
+        Self::_ensure_not_paused(&env)?;
 
         // Prevent overwriting an already active round
         if env.storage().persistent().has(&DataKey::ActiveRound) {
@@ -181,6 +219,7 @@ impl VirtualTokenContract {
             .ok_or(ContractError::AdminNotSet)?;
 
         admin.require_auth();
+        Self::_ensure_not_paused(&env)?;
 
         // Validate both values are positive
         if bet_ledgers == 0 || run_ledgers == 0 {
@@ -236,6 +275,7 @@ impl VirtualTokenContract {
         side: BetSide,
     ) -> Result<(), ContractError> {
         user.require_auth();
+        Self::_ensure_not_paused(&env)?;
 
         if amount <= 0 {
             return Err(ContractError::InvalidBetAmount);
@@ -348,6 +388,7 @@ impl VirtualTokenContract {
         predicted_price: u128,
     ) -> Result<(), ContractError> {
         user.require_auth();
+        Self::_ensure_not_paused(&env)?;
 
         if amount <= 0 {
             return Err(ContractError::InvalidBetAmount);
@@ -487,6 +528,7 @@ impl VirtualTokenContract {
             .ok_or(ContractError::OracleNotSet)?;
 
         oracle.require_auth();
+        Self::_ensure_not_paused(&env)?;
 
         let round: Round = env
             .storage()
@@ -691,6 +733,7 @@ impl VirtualTokenContract {
     /// Claims pending winnings and adds to balance
     pub fn claim_winnings(env: Env, user: Address) -> Result<i128, ContractError> {
         user.require_auth();
+        Self::_ensure_not_paused(&env)?;
 
         let key = DataKey::PendingWinnings(user.clone());
         let pending: i128 = env.storage().persistent().get(&key).unwrap_or(0);
@@ -838,6 +881,9 @@ impl VirtualTokenContract {
     /// Mints 1000 vXLM for new users (one-time only)
     pub fn mint_initial(env: Env, user: Address) -> i128 {
         user.require_auth();
+        if Self::is_paused(env.clone()) {
+            panic_with_error!(&env, ContractError::ContractPaused);
+        }
 
         let key = DataKey::Balance(user.clone());
 
@@ -869,5 +915,13 @@ impl VirtualTokenContract {
     pub(crate) fn _set_balance(env: &Env, user: Address, amount: i128) {
         let key = DataKey::Balance(user);
         env.storage().persistent().set(&key, &amount);
+    }
+
+    fn _ensure_not_paused(env: &Env) -> Result<(), ContractError> {
+        if Self::is_paused(env.clone()) {
+            return Err(ContractError::ContractPaused);
+        }
+
+        Ok(())
     }
 }

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -49,4 +49,6 @@ pub enum ContractError {
     RoundAlreadyActive = 20,
     /// Admin and Oracle addresses cannot be identical
     AdminIsOracle = 21,
+    /// Contract is paused for emergency recovery
+    ContractPaused = 22,
 }

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod edge_cases;
 mod initialization;
 mod lifecycle;
 mod mode_tests;
+mod pause;
 mod property_invariants;
 mod resolution;
 mod security;

--- a/contracts/src/tests/pause.rs
+++ b/contracts/src/tests/pause.rs
@@ -1,0 +1,116 @@
+//! Tests for emergency pause and recovery controls.
+
+use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};
+use crate::errors::ContractError;
+use crate::types::{BetSide, OraclePayload};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+fn setup_contract(env: &Env) -> (VirtualTokenContractClient<'_>, Address, Address) {
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    (client, admin, oracle)
+}
+
+#[test]
+fn test_pause_and_unpause_by_admin() {
+    let env = Env::default();
+    let (client, _admin, _oracle) = setup_contract(&env);
+
+    assert!(!client.is_paused());
+
+    client.pause_contract();
+    assert!(client.is_paused());
+
+    client.unpause_contract();
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_pause_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause_contract",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_pause_contract();
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_mutations_fail_while_paused() {
+    let env = Env::default();
+    let (client, admin, oracle) = setup_contract(&env);
+    let user = Address::generate(&env);
+
+    client.mint_initial(&user);
+    client.pause_contract();
+    assert!(client.is_paused());
+    assert_eq!(client.get_admin(), Some(admin));
+    assert_eq!(client.get_oracle(), Some(oracle));
+    assert_eq!(client.balance(&user), 1000_0000000);
+
+    let create_round_result = client.try_create_round(&1_0000000, &None);
+    assert_eq!(create_round_result, Err(Ok(ContractError::ContractPaused)));
+
+    let bet_result = client.try_place_bet(&user, &10_0000000, &BetSide::Up);
+    assert_eq!(bet_result, Err(Ok(ContractError::ContractPaused)));
+
+    let predict_result = client.try_place_precision_prediction(&user, &10_0000000, &2297);
+    assert_eq!(predict_result, Err(Ok(ContractError::ContractPaused)));
+
+    let windows_result = client.try_set_windows(&8, &16);
+    assert_eq!(windows_result, Err(Ok(ContractError::ContractPaused)));
+
+    let claim_result = client.try_claim_winnings(&user);
+    assert_eq!(claim_result, Err(Ok(ContractError::ContractPaused)));
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+    });
+    let resolve_result = client.try_resolve_round(&OraclePayload {
+        price: 1_5000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+    });
+    assert_eq!(resolve_result, Err(Ok(ContractError::ContractPaused)));
+
+    client.unpause_contract();
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_mint_initial_fails_while_paused() {
+    let env = Env::default();
+    let (client, _admin, _oracle) = setup_contract(&env);
+    let user = Address::generate(&env);
+
+    client.pause_contract();
+
+    let result = client.try_mint_initial(&user);
+    assert!(result.is_err());
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -24,6 +24,7 @@ pub enum DataKey {
     PrecisionPositions, // Map<Address, PrecisionPrediction> for Precision mode
     PendingWinnings(Address),
     UserStats(Address),
+    Paused,
     BetWindowLedgers, // Bet window duration in ledgers
     RunWindowLedgers, // Run window duration in ledgers
     LastRoundId,      // Counter for monotonically increasing round IDs


### PR DESCRIPTION
## Description
Adds an admin-controlled emergency pause state that blocks state-mutating actions while preserving read-only access.

## Changes
- Added a persistent paused flag plus `is_paused`, `pause_contract`, and `unpause_contract`
- Guarded state-mutating contract methods with pause checks
- Added tests for pause/unpause, blocked mutations, and safe reads during pause
- Updated the README and regenerated TypeScript bindings

## Closes
Closes #46

## Notes
- `mint_initial` is blocked while paused so recovery mode stays consistent.
