### PR TITLE
fix(bindings): rename package to @xelma/bindings and add canonical metadata

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,46 @@
+# Migration Notes
+
+## Package Rename: `@tevalabs/xelma-bindings` → `@xelma/bindings`
+
+**Introduced in:** `fix/bindings-package-metadata`
+
+### What changed
+
+The npm package name was updated from the placeholder org-scoped name
+`@tevalabs/xelma-bindings` to the canonical Xelma namespace `@xelma/bindings`.
+
+The following metadata fields were also added or corrected:
+
+| Field | Before | After |
+|-------|--------|-------|
+| `name` | `@tevalabs/xelma-bindings` | `@xelma/bindings` |
+| `repository` | _(absent)_ | `https://github.com/TevaLabs/Xelma-Blockchain` |
+| `author` | _(absent)_ | `TevaLabs` |
+| `license` | _(absent)_ | `MIT` |
+
+### Migration steps for consumers
+
+1. **Uninstall the old package** (if previously published under the old name):
+
+   ```sh
+   npm uninstall @tevalabs/xelma-bindings
+   ```
+
+2. **Install the new package:**
+
+   ```sh
+   npm install @xelma/bindings
+   ```
+
+3. **Update all import statements:**
+
+   ```diff
+   - import { Client } from '@tevalabs/xelma-bindings';
+   + import { Client } from '@xelma/bindings';
+   ```
+
+### Import path impact
+
+Only the package name changed. All exported symbols (`Client`, `ContractError`,
+`BetSide`, `RoundMode`, `UserPosition`, etc.) remain identical — no code changes
+are required beyond updating the import path.

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "@tevalabs/xelma-bindings",
+  "name": "@xelma/bindings",
   "version": "1.1.0",
-  "description": "TypeScript bindings for Xelma-Blockchain smart contracts",
+  "description": "TypeScript bindings for the Xelma on-chain prediction market smart contract",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TevaLabs/Xelma-Blockchain"
+  },
+  "author": "TevaLabs",
+  "license": "MIT",
   "scripts": {
     "build": "tsc",
     "test:parity": "node src/parity.js",

--- a/bindings/src/index.ts
+++ b/bindings/src/index.ts
@@ -124,7 +124,11 @@ export const ContractError = {
   /**
    * Contract is paused for emergency recovery
    */
-  22: {message:"ContractPaused"}
+  22: {message:"ContractPaused"},
+  /**
+   * One or more window values exceed configured maximum bounds
+   */
+  23: {message:"WindowOutOfRange"}
 }
 
 /**


### PR DESCRIPTION
Closes #81

## Summary
- Renames the npm package from the placeholder `@tevalabs/xelma-bindings` to the canonical scoped name `@xelma/bindings`.
- Adds the missing `repository`, `author`, and `license` (`MIT`) fields to `bindings/package.json`.
- Adds the missing `WindowOutOfRange` (code 23) variant to the TypeScript `ContractError` map (it existed in the Rust enum but had drifted out of the bindings).
- Adds `MIGRATION.md` documenting the rename and the consumer import-path change.

## Test plan
- [x] `npm pack --dry-run` from `bindings/` shows the new identity fields.
- [x] Existing CI pipeline (`bindings-build`, `parity-check`) continues to pass — no consumer-facing import paths change beyond the package name itself.
- [x] `MIGRATION.md` walks consumers through the one-line import update.