### PR TITLE
feat: economic integrity, event schema, oracle heartbeat, CI security gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,10 +221,55 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
 
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-audit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-audit-
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run dependency vulnerability audit
+        # Fails on any vulnerability with CVSS score >= 7.0 (high/critical).
+        # Use --deny warnings to also surface advisory-level findings in CI output.
+        run: cargo audit --deny warnings
+
+      - name: Run security-oriented clippy lints
+        # These lints catch common unsafe patterns beyond the default clippy set.
+        run: |
+          cargo clippy --workspace --all-targets --locked -- \
+            -D clippy::unwrap_used \
+            -D clippy::expect_used \
+            -D clippy::panic \
+            -D clippy::integer_arithmetic \
+            -W clippy::arithmetic_side_effects \
+            -W clippy::cast_possible_truncation \
+            -W clippy::cast_sign_loss \
+            2>&1 | tee /tmp/clippy-security.txt
+          # Surface the results; non-zero exit propagates naturally
+          cat /tmp/clippy-security.txt
+
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [rust-test, contract-build, bindings-test, bindings-build, parity-check, format-check]
+    needs: [rust-test, contract-build, bindings-test, bindings-build, parity-check, format-check, security-audit]
     if: always()
     steps:
       - name: Check all jobs status
@@ -234,7 +279,8 @@ jobs:
              [ "${{ needs.bindings-test.result }}" != "success" ] || \
              [ "${{ needs.bindings-build.result }}" != "success" ] || \
              [ "${{ needs.parity-check.result }}" != "success" ] || \
-             [ "${{ needs.format-check.result }}" != "success" ]; then
+             [ "${{ needs.format-check.result }}" != "success" ] || \
+             [ "${{ needs.security-audit.result }}" != "success" ]; then
             echo "One or more CI jobs failed"
             echo "Rust Tests: ${{ needs.rust-test.result }}"
             echo "Contract Build: ${{ needs.contract-build.result }}"
@@ -242,6 +288,7 @@ jobs:
             echo "Bindings Build: ${{ needs.bindings-build.result }}"
             echo "Parity Check: ${{ needs.parity-check.result }}"
             echo "Format Check: ${{ needs.format-check.result }}"
+            echo "Security Audit: ${{ needs.security-audit.result }}"
             exit 1
           fi
           echo "All CI checks passed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,45 @@ sent back for detail before they are picked up.
    - `cd bindings && npm ci && npm run build`
    - `cd bindings && npm run test:parity` (ABI drift check; mirrors the CI `bindings-test` job)
 
+## Security Checks (local)
+
+The CI `security-audit` job runs two checks that maintainers and contributors can reproduce locally.
+
+### 1. Dependency vulnerability scan
+
+```bash
+# Install once
+cargo install cargo-audit --locked
+
+# Run from the repo root
+cargo audit --deny warnings
+```
+
+Findings map to RustSec advisories. A non-zero exit means at least one advisory-level issue
+was found. Review the output and update or replace the affected crate, or add an `audit.toml`
+ignore entry with a justification comment if the advisory does not apply to this project.
+
+### 2. Security-oriented clippy lints
+
+```bash
+cargo clippy --workspace --all-targets --locked -- \
+  -D clippy::unwrap_used \
+  -D clippy::expect_used \
+  -D clippy::panic \
+  -D clippy::integer_arithmetic \
+  -W clippy::arithmetic_side_effects \
+  -W clippy::cast_possible_truncation \
+  -W clippy::cast_sign_loss
+```
+
+These lints catch patterns that are benign in general Rust but unsafe in smart-contract
+contexts (silent panics, unchecked integer operations, sign-loss on casts).  CI treats them
+as warnings that are surfaced in the audit job output; errors `-D` will fail the job.
+
+> **Note**: These lints are stricter than the standard `cargo clippy -- -D warnings` run in
+> the `rust-test` job. It is normal for code that passes standard clippy to have findings here.
+> Fix or document each finding before merging contract changes.
+
 ## Canonical Contract Crate
 
 The contract crate name is `xelma-contract`. Do not reintroduce legacy crate naming in build scripts, docs, or CI commands.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ Xelma-Blockchain/
 │       └── release/
 │           └── xelma_contract.wasm  # Compiled contract
 │
+├── docs/
+│   └── EVENT_SCHEMA.md        # Canonical on-chain event schema for indexers
 ├── SECURITY_REVIEW.md         # Comprehensive security audit
 ├── Cargo.toml                 # Workspace configuration
 └── README.md                  # This file
@@ -322,6 +324,8 @@ We take security seriously. The contract has undergone comprehensive hardening:
 
 All major state transitions emit standardized events for indexers and frontend consumers. Events follow a consistent format: `(topic_1, topic_2)` → `(payload...)`.
 
+> **Indexer reference**: See [docs/EVENT_SCHEMA.md](./docs/EVENT_SCHEMA.md) for the full canonical schema, field semantics, units, versioning strategy, and example decode mappings.
+
 ### Event Types:
 
 #### 1. Round Created
@@ -423,6 +427,42 @@ Payload: (
 ```
 
 **Use Case**: Track new users, display welcome messages, analytics.
+
+#### 8. Round Cancelled
+Emitted when admin cancels an active round; all stakes are refunded.
+
+```rust
+Topic: ("round", "cancelled")
+Payload: (
+  round_id: u64,   // Cancelled round
+  reason: u32,     // Admin-supplied reason code
+  pool_up: i128,   // Up-side pool at cancellation (stroops)
+  pool_down: i128  // Down-side pool at cancellation (stroops)
+)
+```
+
+#### 9. Round Fallback (insufficient participants)
+Emitted when a round ends below the minimum-participants threshold; all stakes are refunded.
+
+```rust
+Topic: ("round", "fallback")
+Payload: (
+  round_id: u64,          // Round that triggered the fallback
+  participant_count: u32, // Actual participant count
+  min_required: u32       // Configured minimum that was not met
+)
+```
+
+#### 10. Oracle Heartbeat
+Emitted when the oracle records an on-chain liveness heartbeat.
+
+```rust
+Topic: ("oracle", "heartbeat")
+Payload: (
+  timestamp: u64,  // Unix epoch seconds of the heartbeat
+  status: u32      // 0 = active, 1 = degraded, 2 = offline
+)
+```
 
 ### Event Consumption
 

--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -4,7 +4,8 @@ use soroban_sdk::{contract, contractimpl, panic_with_error, symbol_short, Addres
 
 use crate::errors::ContractError;
 use crate::types::{
-    BetSide, DataKey, OraclePayload, PrecisionPrediction, Round, RoundMode, UserPosition, UserStats,
+    BetSide, DataKey, OracleHeartbeatRecord, OraclePayload, PrecisionPrediction, Round, RoundMode,
+    UserPosition, UserStats,
 };
 
 // ─── Economic control limits ─────────────────────────────────────────────────
@@ -12,6 +13,11 @@ use crate::types::{
 const MIN_CAP_VALUE: i128 = 1;
 /// Upper bound on the minimum-participants config to prevent unbounded gas in resolution.
 const MAX_MIN_PARTICIPANTS: u32 = 10_000;
+
+// ─── Oracle heartbeat limits ──────────────────────────────────────────────────
+const DEFAULT_ORACLE_STALE_THRESHOLD: u64 = 3_600; // 1 hour
+const MIN_ORACLE_STALE_THRESHOLD: u64 = 60; // 1 minute
+const MAX_ORACLE_STALE_THRESHOLD: u64 = 86_400; // 24 hours
 
 const DEFAULT_BET_WINDOW_LEDGERS: u32 = 6;
 const DEFAULT_RUN_WINDOW_LEDGERS: u32 = 12;
@@ -210,6 +216,95 @@ impl VirtualTokenContract {
 
     pub fn get_oracle(env: Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Oracle)
+    }
+
+    // ─── Oracle heartbeat and liveness (on-chain health tracking) ───────────
+
+    /// Records an oracle heartbeat (oracle only).
+    /// `status`: 0 = active, 1 = degraded, 2 = offline.
+    /// Stores current ledger timestamp; emits `("oracle", "heartbeat")`.
+    pub fn update_oracle_heartbeat(env: Env, status: u32) -> Result<(), ContractError> {
+        if status > 2 {
+            return Err(ContractError::InvalidOracleStatus);
+        }
+        let oracle: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Oracle)
+            .ok_or(ContractError::OracleNotSet)?;
+        oracle.require_auth();
+
+        let ts = env.ledger().timestamp();
+        let record = OracleHeartbeatRecord {
+            timestamp: ts,
+            status,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::OracleHeartbeat, &record);
+
+        #[allow(deprecated)]
+        env.events().publish(
+            (symbol_short!("oracle"), symbol_short!("heartbeat")),
+            (ts, status),
+        );
+        Ok(())
+    }
+
+    /// Returns the most recent oracle heartbeat record, if any.
+    pub fn get_oracle_heartbeat(env: Env) -> Option<OracleHeartbeatRecord> {
+        env.storage().persistent().get(&DataKey::OracleHeartbeat)
+    }
+
+    /// Returns `true` if the oracle has a non-stale heartbeat with status not offline (2).
+    /// Uses the configured stale threshold, defaulting to 3600 seconds.
+    pub fn is_oracle_live(env: Env) -> bool {
+        let record: OracleHeartbeatRecord = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleHeartbeat)
+        {
+            Some(r) => r,
+            None => return false,
+        };
+        if record.status == 2 {
+            return false;
+        }
+        let threshold: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleStaleThreshold)
+            .unwrap_or(DEFAULT_ORACLE_STALE_THRESHOLD);
+        let current_time = env.ledger().timestamp();
+        current_time <= record.timestamp.saturating_add(threshold)
+    }
+
+    /// Sets the stale heartbeat threshold in seconds (admin only).
+    /// Allowed range: 60–86400 seconds (1 minute to 24 hours).
+    pub fn set_oracle_stale_threshold(env: Env, seconds: u64) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::AdminNotSet)?;
+        admin.require_auth();
+        Self::_ensure_not_paused(&env)?;
+
+        if seconds < MIN_ORACLE_STALE_THRESHOLD || seconds > MAX_ORACLE_STALE_THRESHOLD {
+            return Err(ContractError::InvalidStaleThreshold);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::OracleStaleThreshold, &seconds);
+        Ok(())
+    }
+
+    /// Returns the configured oracle stale threshold, or the default (3600 s) if not set.
+    pub fn get_oracle_stale_threshold(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::OracleStaleThreshold)
+            .unwrap_or(DEFAULT_ORACLE_STALE_THRESHOLD)
     }
 
     /// Sets the betting and execution windows (admin only)

--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -10,6 +10,8 @@ use crate::types::{
 // ─── Economic control limits ─────────────────────────────────────────────────
 /// Minimum allowed value when setting an economic cap to prevent zero-value lockouts.
 const MIN_CAP_VALUE: i128 = 1;
+/// Upper bound on the minimum-participants config to prevent unbounded gas in resolution.
+const MAX_MIN_PARTICIPANTS: u32 = 10_000;
 
 const DEFAULT_BET_WINDOW_LEDGERS: u32 = 6;
 const DEFAULT_RUN_WINDOW_LEDGERS: u32 = 12;
@@ -356,6 +358,36 @@ impl VirtualTokenContract {
     /// Returns the current maximum pending winnings cap, if set.
     pub fn get_max_pending_winnings(env: Env) -> Option<i128> {
         env.storage().persistent().get(&DataKey::MaxPendingWinnings)
+    }
+
+    // ─── Minimum participants (competitive settlement integrity) ─────────────
+
+    /// Sets the minimum participant count required for competitive settlement (admin only).
+    /// Rounds that end below this threshold are refunded to all participants.
+    /// Pass `None` to disable the threshold.
+    pub fn set_min_participants(env: Env, min: Option<u32>) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::AdminNotSet)?;
+        admin.require_auth();
+        Self::_ensure_not_paused(&env)?;
+
+        if let Some(v) = min {
+            if v == 0 || v > MAX_MIN_PARTICIPANTS {
+                return Err(ContractError::InvalidMinParticipants);
+            }
+            env.storage().persistent().set(&DataKey::MinParticipants, &v);
+        } else {
+            env.storage().persistent().remove(&DataKey::MinParticipants);
+        }
+        Ok(())
+    }
+
+    /// Returns the current minimum participant threshold, if set.
+    pub fn get_min_participants(env: Env) -> Option<u32> {
+        env.storage().persistent().get(&DataKey::MinParticipants)
     }
 
     /// Returns user statistics (wins, losses, streaks)
@@ -830,6 +862,29 @@ impl VirtualTokenContract {
 
         // Store round ID before cleaning up
         let round_id = round.round_id;
+
+        // ─── Minimum participants threshold check ────────────────────────────
+        if let Some(min) = env
+            .storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::MinParticipants)
+        {
+            let threshold_participants: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::RoundParticipants(round_id))
+                .unwrap_or(Vec::new(&env));
+            let count = threshold_participants.len() as u32;
+            if count < min {
+                Self::_refund_under_threshold(&env, &round, &threshold_participants)?;
+                #[allow(deprecated)]
+                env.events().publish(
+                    (symbol_short!("round"), symbol_short!("fallback")),
+                    (round_id, count, min),
+                );
+                return Ok(());
+            }
+        }
 
         // Branch based on round mode
         match round.mode {
@@ -1399,6 +1454,62 @@ impl VirtualTokenContract {
             }
         }
 
+        Ok(())
+    }
+
+    /// Refunds all participant stakes when the minimum-participants threshold is not met.
+    /// Performs the same key cleanup as normal resolution so the contract is left consistent.
+    fn _refund_under_threshold(
+        env: &Env,
+        round: &Round,
+        participants: &Vec<Address>,
+    ) -> Result<(), ContractError> {
+        let round_id = round.round_id;
+        match round.mode {
+            RoundMode::UpDown => {
+                for i in 0..participants.len() {
+                    if let Some(user) = participants.get(i) {
+                        let pos_key = DataKey::Position(round_id, user.clone());
+                        if let Some(pos) =
+                            env.storage().persistent().get::<_, UserPosition>(&pos_key)
+                        {
+                            Self::_accumulate_pending(env, user, pos.amount)?;
+                        }
+                    }
+                }
+            }
+            RoundMode::Precision => {
+                for i in 0..participants.len() {
+                    if let Some(user) = participants.get(i) {
+                        let pred_key = DataKey::PrecisionPosition(round_id, user.clone());
+                        if let Some(pred) = env
+                            .storage()
+                            .persistent()
+                            .get::<_, PrecisionPrediction>(&pred_key)
+                        {
+                            Self::_accumulate_pending(env, user, pred.amount)?;
+                        }
+                    }
+                }
+            }
+        }
+        for i in 0..participants.len() {
+            if let Some(user) = participants.get(i) {
+                env.storage()
+                    .persistent()
+                    .remove(&DataKey::Position(round_id, user.clone()));
+                env.storage()
+                    .persistent()
+                    .remove(&DataKey::PrecisionPosition(round_id, user));
+            }
+        }
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RoundParticipants(round_id));
+        env.storage().persistent().remove(&DataKey::ActiveRound);
+        env.storage().persistent().remove(&DataKey::Positions);
+        env.storage().persistent().remove(&DataKey::UpDownPositions);
+        env.storage().persistent().remove(&DataKey::PrecisionPositions);
         Ok(())
     }
 

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -73,4 +73,8 @@ pub enum ContractError {
     InsufficientParticipants = 32,
     /// Minimum participants value is out of valid range (must be 1–10000)
     InvalidMinParticipants = 33,
+    /// Oracle heartbeat status is out of range (must be 0, 1, or 2)
+    InvalidOracleStatus = 34,
+    /// Oracle stale threshold is out of valid range (must be 60–86400 seconds)
+    InvalidStaleThreshold = 35,
 }

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -69,4 +69,8 @@ pub enum ContractError {
     PendingWinningsCapExceeded = 30,
     /// Oracle payload nonce was already consumed for this round (replay)
     OracleNonceReused = 31,
+    /// Round has fewer participants than the configured minimum for competitive settlement
+    InsufficientParticipants = 32,
+    /// Minimum participants value is out of valid range (must be 1–10000)
+    InvalidMinParticipants = 33,
 }

--- a/contracts/src/tests/resolution.rs
+++ b/contracts/src/tests/resolution.rs
@@ -1445,6 +1445,223 @@ fn test_precision_payout_conservation_two_way_tie_remainder() {
     assert_eq!(alice_payout + bob_payout, per_winner * 2 + remainder);
 }
 
+// ============================================================================
+// MINIMUM PARTICIPANTS THRESHOLD TESTS
+// ============================================================================
+
+#[test]
+fn test_min_participants_blocks_settlement_updown() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let user1 = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&user1);
+    client.create_round(&1_0000000, &None);
+
+    client.place_bet(&user1, &100_0000000, &BetSide::Up);
+    client.set_min_participants(&Some(2u32));
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+    });
+
+    let balance_before = client.balance(&user1);
+
+    client.resolve_round(&OraclePayload {
+        price: 1_5000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+    });
+
+    // Stake refunded to pending winnings, not claimed yet
+    assert_eq!(client.get_pending_winnings(&user1), 100_0000000);
+    assert_eq!(client.balance(&user1), balance_before);
+    assert_eq!(client.get_active_round(), None);
+}
+
+#[test]
+fn test_min_participants_allows_settlement_at_threshold() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&user1);
+    client.mint_initial(&user2);
+    client.create_round(&1_0000000, &None);
+
+    client.place_bet(&user1, &100_0000000, &BetSide::Up);
+    client.place_bet(&user2, &100_0000000, &BetSide::Down);
+    client.set_min_participants(&Some(2u32));
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+    });
+
+    // Resolve with higher price → user1 (Up) wins the pot
+    client.resolve_round(&OraclePayload {
+        price: 1_5000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+    });
+
+    assert_eq!(client.get_pending_winnings(&user1), 200_0000000);
+    assert_eq!(client.get_pending_winnings(&user2), 0);
+    assert_eq!(client.get_active_round(), None);
+}
+
+#[test]
+fn test_min_participants_fallback_refunds_precision_mode() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let user1 = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&user1);
+    client.create_round(&2000, &Some(1));
+
+    client.place_precision_prediction(&user1, &100_0000000, &2100u128);
+    client.set_min_participants(&Some(2u32));
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+    });
+
+    client.resolve_round(&OraclePayload {
+        price: 2200,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+    });
+
+    // Precision bet refunded
+    assert_eq!(client.get_pending_winnings(&user1), 100_0000000);
+    assert_eq!(client.get_active_round(), None);
+}
+
+#[test]
+fn test_min_participants_fallback_event_emitted() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let user1 = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&user1);
+    client.create_round(&1_0000000, &None);
+    client.place_bet(&user1, &100_0000000, &BetSide::Up);
+    client.set_min_participants(&Some(3u32));
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+    });
+
+    client.resolve_round(&OraclePayload {
+        price: 1_5000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+    });
+
+    let events = env.events().all();
+    let fallback_event = events.iter().find(|e| {
+        let (_contract, topics, _data) = e;
+        topics.len() == 2
+            && topics.get(0).unwrap().try_into_val(&env) == Ok(symbol_short!("round"))
+            && topics.get(1).unwrap().try_into_val(&env) == Ok(symbol_short!("fallback"))
+    });
+    assert!(
+        fallback_event.is_some(),
+        "Fallback event must be emitted when min-participants threshold is not met"
+    );
+}
+
+#[test]
+fn test_set_min_participants_validation() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // Zero is invalid
+    let result = client.try_set_min_participants(&Some(0u32));
+    assert_eq!(result, Err(Ok(ContractError::InvalidMinParticipants)));
+
+    // Exceeding max is invalid
+    let result = client.try_set_min_participants(&Some(10_001u32));
+    assert_eq!(result, Err(Ok(ContractError::InvalidMinParticipants)));
+
+    // Valid value accepted
+    client.set_min_participants(&Some(2u32));
+    assert_eq!(client.get_min_participants(), Some(2u32));
+
+    // None removes the threshold
+    client.set_min_participants(&None);
+    assert_eq!(client.get_min_participants(), None);
+}
+
+#[test]
+fn test_no_min_participants_threshold_resolves_normally() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let user1 = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&user1);
+    client.create_round(&1_0000000, &None);
+
+    // Place a single bet with no min threshold configured
+    client.place_bet(&user1, &100_0000000, &BetSide::Up);
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+    });
+
+    // Should resolve normally (single participant wins their own pool with no opposing side)
+    client.resolve_round(&OraclePayload {
+        price: 1_5000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+    });
+
+    // Price went up but winning_pool (Up) = 100, losing_pool (Down) = 0 → payout = 100 + 0 = 100
+    assert_eq!(client.get_pending_winnings(&user1), 100_0000000);
+    assert_eq!(client.get_active_round(), None);
+}
+
 /// Verifies conservation and non-overflow for a large tie set (10 winners).
 #[test]
 fn test_precision_payout_conservation_large_tie_set() {

--- a/contracts/src/tests/security.rs
+++ b/contracts/src/tests/security.rs
@@ -4,7 +4,8 @@ use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};
 use crate::errors::ContractError;
 use crate::types::{DataKey, OraclePayload};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger as _},
+    symbol_short,
+    testutils::{Address as _, Events, Ledger as _, TryIntoVal},
     Address, Env, IntoVal,
 };
 
@@ -274,6 +275,274 @@ fn test_resolve_round_unique_nonce_resolves() {
             .unwrap_or(false);
         assert!(consumed, "resolved nonce must be marked consumed");
     });
+}
+
+// ─── Oracle heartbeat and liveness tests ─────────────────────────────────────
+
+#[test]
+fn test_oracle_heartbeat_requires_oracle_auth() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize",
+            args: (&admin, &oracle).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize(&admin, &oracle);
+
+    // No oracle auth set up — must fail
+    let result = client.try_update_oracle_heartbeat(&0u32);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_oracle_heartbeat_updates_timestamp_and_status() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 500;
+    });
+
+    client.update_oracle_heartbeat(&0u32);
+
+    let record = client.get_oracle_heartbeat().expect("heartbeat must exist");
+    assert_eq!(record.timestamp, 500);
+    assert_eq!(record.status, 0);
+
+    // Update to degraded status
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    client.update_oracle_heartbeat(&1u32);
+
+    let record = client.get_oracle_heartbeat().unwrap();
+    assert_eq!(record.timestamp, 1000);
+    assert_eq!(record.status, 1);
+}
+
+#[test]
+fn test_oracle_heartbeat_invalid_status_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    let result = client.try_update_oracle_heartbeat(&3u32);
+    assert_eq!(result, Err(Ok(ContractError::InvalidOracleStatus)));
+}
+
+#[test]
+fn test_oracle_liveness_within_threshold() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // Heartbeat at t=0
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Check liveness 100 s later (well within 3600 s default)
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+    assert!(client.is_oracle_live());
+}
+
+#[test]
+fn test_oracle_liveness_stale_after_threshold() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // Heartbeat at t=0
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Check 4000 s later — beyond 3600 s default threshold
+    env.ledger().with_mut(|li| {
+        li.timestamp = 4000;
+    });
+    assert!(!client.is_oracle_live());
+}
+
+#[test]
+fn test_oracle_liveness_offline_status_not_live() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    // Record offline status
+    client.update_oracle_heartbeat(&2u32);
+
+    // Even within threshold, offline means not live
+    env.ledger().with_mut(|li| {
+        li.timestamp = 10;
+    });
+    assert!(!client.is_oracle_live());
+}
+
+#[test]
+fn test_oracle_liveness_no_heartbeat_returns_false() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // No heartbeat recorded — must return false
+    assert!(!client.is_oracle_live());
+}
+
+#[test]
+fn test_oracle_heartbeat_event_emitted() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    client.update_oracle_heartbeat(&0u32);
+
+    let events = env.events().all();
+    let hb_event = events.iter().find(|e| {
+        let (_contract, topics, _data) = e;
+        topics.len() == 2
+            && topics.get(0).unwrap().try_into_val(&env) == Ok(symbol_short!("oracle"))
+            && topics.get(1).unwrap().try_into_val(&env) == Ok(symbol_short!("heartbeat"))
+    });
+    assert!(
+        hb_event.is_some(),
+        "Heartbeat event must be emitted on update_oracle_heartbeat"
+    );
+}
+
+#[test]
+fn test_set_oracle_stale_threshold_admin_only() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize",
+            args: (&admin, &oracle).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize(&admin, &oracle);
+
+    // No admin auth for set_oracle_stale_threshold
+    let result = client.try_set_oracle_stale_threshold(&1800u64);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_oracle_stale_threshold_validation() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // Below minimum (< 60)
+    let result = client.try_set_oracle_stale_threshold(&59u64);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStaleThreshold)));
+
+    // Above maximum (> 86400)
+    let result = client.try_set_oracle_stale_threshold(&86_401u64);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStaleThreshold)));
+
+    // Valid value
+    client.set_oracle_stale_threshold(&1800u64);
+    assert_eq!(client.get_oracle_stale_threshold(), 1800u64);
+}
+
+#[test]
+fn test_oracle_liveness_custom_threshold() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // Set a short 120 s threshold
+    client.set_oracle_stale_threshold(&120u64);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // 100 s later — within custom 120 s threshold
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+    assert!(client.is_oracle_live());
+
+    // 130 s later — beyond 120 s threshold
+    env.ledger().with_mut(|li| {
+        li.timestamp = 130;
+    });
+    assert!(!client.is_oracle_live());
 }
 
 /// Boundary nonces (0 and u64::MAX) are rejected on reuse for the same round.

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -60,6 +60,10 @@ pub enum DataKey {
     ConsumedOracleNonce(u64, u64),
     /// Minimum participant count for competitive settlement; unset = no minimum enforced
     MinParticipants,
+    /// Oracle heartbeat: last recorded timestamp and status
+    OracleHeartbeat,
+    /// Stale-heartbeat threshold in seconds (admin-configurable); unset = 3600 s default
+    OracleStaleThreshold,
 }
 
 /// Represents which side a user bet on
@@ -110,6 +114,15 @@ pub struct OraclePayload {
     /// `DataKey::ConsumedOracleNonce(round_id, nonce)` and rejects any reuse,
     /// making resolution idempotent against accidental duplicate submissions.
     pub nonce: u64,
+}
+
+/// Oracle liveness record, updated by the oracle service on each heartbeat call.
+/// `status`: 0 = active, 1 = degraded, 2 = offline.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct OracleHeartbeatRecord {
+    pub timestamp: u64,
+    pub status: u32,
 }
 
 #[contracttype]

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -58,6 +58,8 @@ pub enum DataKey {
     /// Per-round consumed oracle nonce: (round_id, nonce) → true.
     /// Used to reject duplicate oracle payload submissions for the same round.
     ConsumedOracleNonce(u64, u64),
+    /// Minimum participant count for competitive settlement; unset = no minimum enforced
+    MinParticipants,
 }
 
 /// Represents which side a user bet on

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -1,0 +1,209 @@
+# Xelma Contract — Canonical Event Schema
+
+This document is the authoritative reference for all events emitted by the Xelma smart contract.
+Indexers, explorers, and client libraries must use these definitions to avoid incompatible
+field assumptions.
+
+---
+
+## Versioning strategy
+
+Events are versioned by **schema version tag** in the documentation rather than on-chain.
+Breaking field changes will increment the schema version and are announced in `MIGRATION.md`.
+Additive changes (new optional events) do not increment the version.
+
+Current schema version: **v1**
+
+---
+
+## Encoding conventions
+
+| Field type   | On-chain encoding                                      |
+|--------------|--------------------------------------------------------|
+| `u32`        | Raw unsigned 32-bit integer                            |
+| `u64`        | Raw unsigned 64-bit integer                            |
+| `u128`       | Raw unsigned 128-bit integer                           |
+| `i128`       | Raw signed 128-bit integer                             |
+| `Address`    | Soroban `Address` (account or contract)                |
+| `bool`       | Soroban boolean                                        |
+
+**Amount units**: all token amounts are in stroops (1 vXLM = 10 000 000 stroops, 7 decimal places).
+
+**Price units**: prices are scaled to **4 decimal places** (e.g., 0.2297 XLM → `2297`).
+
+**Ledger sequence**: `u32` counter that increments with each Stellar ledger (~5 s/ledger).
+
+**Timestamp**: Unix epoch seconds (`u64`), sourced from oracle payload or `env.ledger().timestamp()`.
+
+---
+
+## Topic encoding
+
+Each event carries exactly **two topics**, both `Symbol` values.  
+They form the canonical `(namespace, action)` pair used for filtering.
+
+---
+
+## Events
+
+### `("round", "created")`
+
+Emitted when a new prediction round is opened.
+
+| Position | Field            | Type   | Description                                                     |
+|----------|------------------|--------|-----------------------------------------------------------------|
+| 0        | `round_id`       | `u64`  | Monotonically increasing round identifier                       |
+| 1        | `start_price`    | `u128` | Starting XLM price (4 decimal places)                          |
+| 2        | `start_ledger`   | `u32`  | Ledger sequence number when the round was created               |
+| 3        | `bet_end_ledger` | `u32`  | Last ledger at which new bets are accepted                      |
+| 4        | `end_ledger`     | `u32`  | Ledger at or after which the round can be resolved              |
+| 5        | `mode`           | `u32`  | Round mode: `0` = UpDown, `1` = Precision                      |
+
+---
+
+### `("bet", "placed")`
+
+Emitted when a user places an Up/Down bet.
+
+| Position | Field      | Type      | Description                                      |
+|----------|------------|-----------|--------------------------------------------------|
+| 0        | `user`     | `Address` | User who placed the bet                          |
+| 1        | `round_id` | `u64`     | Round the bet belongs to                         |
+| 2        | `amount`   | `i128`    | Bet amount in stroops                            |
+| 3        | `side`     | `u32`     | Prediction side: `0` = Up, `1` = Down            |
+
+---
+
+### `("predict", "price")`
+
+Emitted when a user submits a Precision mode price prediction.
+
+| Position | Field             | Type      | Description                                          |
+|----------|-------------------|-----------|------------------------------------------------------|
+| 0        | `user`            | `Address` | User who submitted the prediction                    |
+| 1        | `round_id`        | `u64`     | Round the prediction belongs to                      |
+| 2        | `predicted_price` | `u128`    | Predicted price (4 decimal places)                   |
+| 3        | `amount`          | `i128`    | Bet amount in stroops                                |
+
+---
+
+### `("round", "resolved")`
+
+Emitted when a round is settled competitively by the oracle.
+
+| Position | Field         | Type   | Description                                      |
+|----------|---------------|--------|--------------------------------------------------|
+| 0        | `round_id`    | `u64`  | Round that was resolved                          |
+| 1        | `final_price` | `u128` | Closing price reported by the oracle (4 dec.)    |
+| 2        | `mode`        | `u32`  | Round mode: `0` = UpDown, `1` = Precision        |
+
+---
+
+### `("round", "cancelled")`
+
+Emitted when an admin explicitly cancels an active round. All stakes are refunded.
+
+| Position | Field       | Type   | Description                                             |
+|----------|-------------|--------|---------------------------------------------------------|
+| 0        | `round_id`  | `u64`  | Round that was cancelled                                |
+| 1        | `reason`    | `u32`  | Admin-supplied reason code (application-defined)        |
+| 2        | `pool_up`   | `i128` | Total Up-side pool at cancellation time (in stroops)    |
+| 3        | `pool_down` | `i128` | Total Down-side pool at cancellation time (in stroops)  |
+
+---
+
+### `("round", "fallback")`
+
+Emitted when a round ends below the configured minimum-participants threshold.
+All stakes are refunded; no competitive settlement occurs.
+
+| Position | Field               | Type  | Description                                         |
+|----------|---------------------|-------|-----------------------------------------------------|
+| 0        | `round_id`          | `u64` | Round that triggered the fallback                   |
+| 1        | `participant_count` | `u32` | Actual number of participants at resolution time    |
+| 2        | `min_required`      | `u32` | Configured minimum that was not met                 |
+
+---
+
+### `("claim", "winnings")`
+
+Emitted when a user successfully claims pending winnings.
+
+| Position | Field    | Type      | Description                             |
+|----------|-----------|-----------|-----------------------------------------|
+| 0        | `user`   | `Address` | User who claimed                        |
+| 1        | `amount` | `i128`    | Amount credited to balance (in stroops) |
+
+---
+
+### `("mint", "initial")`
+
+Emitted when a new user mints their one-time initial vXLM allocation.
+
+| Position | Field    | Type      | Description                             |
+|----------|-----------|-----------|-----------------------------------------|
+| 0        | `user`   | `Address` | User who received the allocation        |
+| 1        | `amount` | `i128`    | Minted amount (always 10 000 000 000 stroops = 1 000 vXLM) |
+
+---
+
+### `("windows", "updated")`
+
+Emitted when the admin reconfigures the bet and run window lengths.
+
+| Position | Field                | Type  | Description                                  |
+|----------|----------------------|-------|----------------------------------------------|
+| 0        | `bet_window_ledgers` | `u32` | New bet-acceptance window in ledger counts    |
+| 1        | `run_window_ledgers` | `u32` | New round-duration window in ledger counts    |
+
+---
+
+### `("oracle", "heartbeat")`
+
+Emitted when the oracle records an on-chain liveness heartbeat.
+
+| Position | Field       | Type  | Description                                                  |
+|----------|-------------|-------|--------------------------------------------------------------|
+| 0        | `timestamp` | `u64` | Unix epoch seconds when the heartbeat was recorded on-chain  |
+| 1        | `status`    | `u32` | Oracle status: `0` = active, `1` = degraded, `2` = offline  |
+
+---
+
+## Example decode mappings
+
+### JavaScript / TypeScript (Stellar SDK)
+
+```typescript
+import { xdr, scValToNative } from "@stellar/stellar-sdk";
+
+function decodeEvent(contractEvent: xdr.DiagnosticEvent) {
+  const topics = contractEvent.event().body().v0().topics();
+  const ns = scValToNative(topics[0]) as string;    // e.g. "round"
+  const action = scValToNative(topics[1]) as string; // e.g. "created"
+  const data = scValToNative(contractEvent.event().body().v0().data());
+  return { ns, action, data };
+}
+```
+
+### Rust (soroban-sdk test utilities)
+
+```rust
+use soroban_sdk::{symbol_short, testutils::{Events, TryIntoVal}, Env};
+
+let events = env.events().all();
+let resolved = events.iter().find(|(_, topics, _)| {
+    topics.get(0).and_then(|t| t.try_into_val(&env).ok()) == Some(symbol_short!("round"))
+        && topics.get(1).and_then(|t| t.try_into_val(&env).ok()) == Some(symbol_short!("resolved"))
+});
+```
+
+---
+
+## Field units quick reference
+
+| Concept        | Unit       | Scale factor | Example                              |
+|----------------|------------|--------------|--------------------------------------|
+| Token amount   | stroops    | × 10 000 000 | 1 vXLM = `10_000_000`               |
+| XLM price      | 4 dec.     | × 10 000     | 0.2297 XLM = `2297`                 |
+| Duration       | ledgers    | ~5 s/ledger  | 12 ledgers ≈ 60 seconds             |
+| Timestamp      | Unix epoch | seconds      | `1_700_000_000` = 2023-11-14 ~22:13 |


### PR DESCRIPTION
## Summary

- **Task 1 — Economic integrity**: Added configurable `min_participants` threshold enforced at round settlement. Rounds below threshold are refunded deterministically via `_refund_under_threshold` and emit `("round", "fallback")` event. Includes `set_min_participants` / `get_min_participants` with admin auth and range validation (1–10 000).

- **Task 2 — Indexer event schema**: Created `docs/EVENT_SCHEMA.md` as the canonical reference for all 10 contract events — topics, payload fields, units, versioning strategy, and decode examples for JS/Rust. Linked from `README.md` event section and file tree.

- **Task 3 — Oracle heartbeat**: Added `update_oracle_heartbeat` (oracle-auth, status 0/1/2), `get_oracle_heartbeat`, `is_oracle_live` (stale-check against configurable threshold), `set_oracle_stale_threshold` / `get_oracle_stale_threshold` (admin-auth, 60–86 400 s). Emits `("oracle", "heartbeat")` on each update. 11 new tests in `security.rs` covering auth, status transitions, liveness, stale expiry, and custom thresholds.

- **Task 4 — CI security gates**: Added dedicated `security-audit` CI job running `cargo audit --deny warnings` (RustSec advisory scan) and security-oriented `clippy` lints (`unwrap_used`, `expect_used`, `panic`, `integer_arithmetic`). Job is required for `ci-success`. Local reproduction steps documented in `CONTRIBUTING.md`.

## Related Issues
Closes #107 
Closes #112 
Closes #114 
Closes #123 

