### PR TITLE
test(bindings): add ContractError parity tests and decode helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run bindings tests
         working-directory: bindings
-        run: npm run test:parity
+        run: npm run test:parity && npm run test:errors
 
   bindings-build:
     name: Bindings Build
@@ -205,7 +205,7 @@ jobs:
           echo "Running ABI drift checking script..."
           cd bindings
           npm ci
-          npm run test:parity
+          npm run test:parity && npm run test:errors
 
   format-check:
     name: Format Check

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -52,3 +52,28 @@ contract.|
 ```
 
 As long as your editor is configured to show JavaScript/TypeScript documentation, you can pause your typing at that `|` to get a list of all exports and inline-documentation for each. It exports a separate [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) function for each method in the smart contract, with documentation for each generated from the comments the contract's author included in the original source code.
+
+# Decode contract errors
+
+When a transaction fails, the contract returns a `u32` error code. Use the helpers
+below to translate that code into a structured result or a user-facing string
+suitable for wallet UX.
+
+```ts
+import { decodeContractError, formatContractError } from "bindings"
+
+// Structured result for programmatic handling
+const decoded = decodeContractError(4)
+if (decoded) {
+  console.log(`Error ${decoded.code}: ${decoded.variant} — ${decoded.message}`)
+  // => "Error 4: UnauthorizedAdmin — UnauthorizedAdmin"
+}
+
+// One-liner for display in a wallet or bot
+console.log(formatContractError(9) ?? "Unknown error")
+// => "InsufficientBalance (code 9)"
+```
+
+Use `decodeContractError` to surface contextual information in your wallet or
+bot, and fall back to `"Unknown contract error (code N)"` for codes that the
+current bindings do not yet recognise.

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -15,7 +15,8 @@
     "build": "./node_modules/.bin/tsc",
     "lint": "./node_modules/.bin/tsc --noEmit",
     "test:parity": "node src/parity.js",
-    "prepublishOnly": "npm run build && npm run test:parity"
+    "test:errors": "node tests/contract-error-parity.test.js",
+    "prepublishOnly": "npm run build && npm run test:parity && npm run test:errors"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.5.0",

--- a/bindings/src/index.ts
+++ b/bindings/src/index.ts
@@ -344,49 +344,99 @@ export const ContractError = {
    */
   37: {message:"InvalidStaleThreshold"},
   /**
-   * Oracle max deviation bps is invalid (must be > 0)
+   * Precision participant cap is out of range (must be 1–10000)
    */
-  38: {message:"InvalidOracleDeviationBps"},
-  /**
-   * Oracle final price deviates beyond configured threshold
-   */
-  39: {message:"OracleDeviationExceeded"},
-  /**
-   * Stored schema version is unknown or unsupported by this contract build
-   */
-  40: {message:"UnsupportedSchemaVersion"},
-  /**
-   * Migration path is invalid for the stored schema version
-   */
-  41: {message:"InvalidMigrationPath"},
-  /**
-   * Migration cannot run while a round is active
-   */
-  42: {message:"MigrationActiveRound"},
-  /**
-   * Commitment for precision prediction not found
-   */
-  43: {message:"CommitmentNotFound"},
-  /**
-   * Precision prediction has already been revealed
-   */
-  44: {message:"AlreadyRevealed"},
-  /**
-   * Attempted to reveal prediction outside the valid window
-   */
-  45: {message:"InvalidRevealWindow"},
-  /**
-   * Revealed prediction hash does not match committed hash
-   */
-  46: {message:"HashMismatch"},
+   38: {message:"InvalidPrecisionParticipantCap"},
   /**
    * Precision round has reached the configured participant cap
    */
-  47: {message:"PrecisionParticipantCapExceeded"},
+   39: {message:"PrecisionParticipantCapExceeded"},
   /**
-   * Precision participant cap is out of range (must be 1–10000)
+   * Oracle max deviation bps is invalid (must be > 0)
    */
-  48: {message:"InvalidPrecisionParticipantCap"}
+  40: {message:"InvalidOracleDeviationBps"},
+  /**
+   * Oracle final price deviates beyond configured threshold
+   */
+  41: {message:"OracleDeviationExceeded"},
+  /**
+   * Stored schema version is unknown or unsupported by this contract build
+   */
+  42: {message:"UnsupportedSchemaVersion"},
+  /**
+   * Migration path is invalid for the stored schema version
+   */
+  43: {message:"InvalidMigrationPath"},
+  /**
+   * Migration cannot run while a round is active
+   */
+  44: {message:"MigrationActiveRound"},
+  /**
+   * Commitment for precision prediction not found
+   */
+  45: {message:"CommitmentNotFound"},
+  /**
+   * Precision prediction has already been revealed
+   */
+  46: {message:"AlreadyRevealed"},
+  /**
+   * Attempted to reveal prediction outside the valid window
+   */
+  47: {message:"InvalidRevealWindow"},
+  /**
+   * Revealed prediction hash does not match committed hash
+   */
+  48: {message:"HashMismatch"},
+  /**
+   * Oracle payload network_id does not match the runtime network
+   */
+   49: {message:"OracleNetworkMismatch"},
+  /**
+   * Oracle payload contract_addr does not match the current contract
+   */
+   50: {message:"OracleContractMismatch"},
+  /**
+   * Protocol fee bps is outside the allowed range (must be in 1..=MAX_PROTOCOL_FEE_BPS)
+   */
+   51: {message:"InvalidProtocolFeeBps"},
+  /**
+   * Treasury withdrawal would underflow the accumulated treasury balance
+   */
+   52: {message:"FeeTreasuryUnderflow"}
+}
+
+/**
+ * Decodes a contract error code into a structured result suitable for wallet UX.
+ * @param code - The on-chain u32 error code returned by the contract.
+ * @returns An object with the code, variant name, and human-readable message, or null if the code is unknown.
+ */
+export function decodeContractError(code: number): {
+  code: number;
+  variant: string;
+  message: string;
+} | null {
+  const entry = ContractError[code];
+  if (!entry) {
+    return null;
+  }
+  return {
+    code,
+    variant: entry.message,
+    message: entry.message,
+  };
+}
+
+/**
+ * Formats a contract error code into a user-facing string for wallet display.
+ * Returns a fallback for unknown codes.
+ * @param code - The on-chain u32 error code returned by the contract.
+ */
+export function formatContractError(code: number): string {
+  const decoded = decodeContractError(code);
+  if (!decoded) {
+    return `Unknown contract error (code ${code})`;
+  }
+  return `${decoded.message} (code ${code})`;
 }
 
 export interface Client {

--- a/bindings/tests/contract-error-parity.test.js
+++ b/bindings/tests/contract-error-parity.test.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import assert from "assert";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const errorsPath = path.resolve(__dirname, "../../contracts/src/errors.rs");
+const bindingsPath = path.resolve(__dirname, "../src/index.ts");
+
+const errorsCode = fs.readFileSync(errorsPath, "utf8");
+const bindingsCode = fs.readFileSync(bindingsPath, "utf8");
+
+const rustVariants = [];
+for (const line of errorsCode.split("\n")) {
+  const m = line.match(/^\s*(\w+)\s*=\s*(\d+),?\s*$/);
+  if (m) {
+    rustVariants.push({ name: m[1], code: parseInt(m[2], 10) });
+  }
+}
+
+const tsMapMatch = bindingsCode.match(/export\s+const\s+ContractError\s*=\s*\{([\s\S]*)\}/);
+if (!tsMapMatch) {
+  console.error("Could not find ContractError map in bindings/src/index.ts");
+  process.exit(1);
+}
+
+const tsCodes = new Map();
+const tsEntryRegex = /^\s*(\d+)\s*:\s*\{message:"([^"]+)"\}/gm;
+let entry;
+while ((entry = tsEntryRegex.exec(tsMapMatch[1])) !== null) {
+  tsCodes.set(parseInt(entry[1], 10), entry[2]);
+}
+
+const rustCodes = new Map(rustVariants.map(v => [v.code, v.name]));
+
+const missingInTS = [];
+const extraInTS = [];
+const nameMismatches = [];
+
+for (const [code, name] of rustCodes) {
+  const tsName = tsCodes.get(code);
+  if (!tsName) {
+    missingInTS.push(`${code}: ${name}`);
+  } else if (tsName !== name) {
+    nameMismatches.push(`Code ${code}: Rust name is "${name}", TS name is "${tsName}"`);
+  }
+}
+
+for (const [code, name] of tsCodes) {
+  if (!rustCodes.has(code)) {
+    extraInTS.push(`${code}: ${name}`);
+  }
+}
+
+assert.strictEqual(missingInTS.length, 0, `Missing error codes in TS: ${missingInTS.join(", ")}`);
+assert.strictEqual(extraInTS.length, 0, `Extra error codes in TS (not in Rust): ${extraInTS.join(", ")}`);
+assert.strictEqual(nameMismatches.length, 0, `Error name mismatches: ${nameMismatches.join("; ")}`);
+
+assert(
+  bindingsCode.includes("export function decodeContractError"),
+  "decodeContractError helper is missing from bindings"
+);
+assert(
+  bindingsCode.includes("export function formatContractError"),
+  "formatContractError helper is missing from bindings"
+);
+
+console.log(`✅ Error code parity check passed: ${rustCodes.size} variants mapped correctly.`);


### PR DESCRIPTION
## Summary

This PR adds parity tests to ensure all Rust `ContractError` variants are correctly represented in the TypeScript bindings.

Closes #158

## Changes Made

* Added a canonical error mapping between Rust `ContractError` variants and TypeScript bindings.
* Added parity tests that detect missing or extra error codes.
* Added decode helpers to improve wallet and frontend error handling.
* Added example usage documentation to the bindings README.

## Testing

* Verified all error codes defined in `contracts/src/errors.rs` are represented in the bindings.
* Added automated parity tests to prevent future drift.
* Confirmed tests run successfully in CI.

## Why

Client applications, bots, and wallets rely on accurate error decoding to provide meaningful feedback to users. This change ensures that contract failures are decoded consistently and prevents stale or missing error mappings between the Rust contracts and TypeScript bindings.
