### PR TITLE
Ops query: add protocol_health_check composite status endpoint

### DIFF
--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -9,7 +9,8 @@ use crate::errors::ContractError;
 use crate::types::{
     ArchivedRoundSummary, BetSide, ConfigChangeKind, ConfigChangePayload, DataKey,
     OracleHeartbeatRecord, OraclePayload, PendingConfigChange, PrecisionCommitment,
-    PrecisionPrediction, Round, RoundArchiveStatus, RoundMode, UserPosition, UserStats,
+    PrecisionPrediction, ProtocolHealthStatus, Round, RoundArchiveStatus, RoundMode, UserPosition,
+    UserStats,
 };
 
 // ─── Economic control limits ─────────────────────────────────────────────────
@@ -487,6 +488,109 @@ impl VirtualTokenContract {
     /// Allowed range: 60–86400 seconds (1 minute to 24 hours).
     pub fn set_oracle_stale_threshold(env: Env, seconds: u64) -> Result<(), ContractError> {
         Self::schedule_oracle_stale_threshold(env, seconds)
+    }
+
+    /// Returns a composite protocol health status aggregating pause state,
+    /// oracle liveness, active round phase, and schema version.
+    ///
+    /// Read-only and deterministic — no authentication required.
+    ///
+    /// ## Status code reference
+    ///
+    /// | code | meaning         | when returned                          |
+    /// |------|-----------------|----------------------------------------|
+    /// | 0    | HEALTHY         | All subsystems nominal                 |
+    /// | 1    | PAUSED          | Contract is emergency-paused           |
+    /// | 2    | ORACLE_STALE    | Oracle heartbeat is stale or offline   |
+    /// | 3    | ROUND_STALE     | Round resolvable but unresolved        |
+    /// | 4    | NO_ACTIVE_ROUND | No round active, oracle healthy        |
+    /// | 5    | MULTIPLE_ISSUES | Two or more simultaneous problems      |
+    pub fn get_protocol_health(env: Env) -> ProtocolHealthStatus {
+        let ledger_sequence = env.ledger().sequence();
+        let ledger_timestamp = env.ledger().timestamp();
+
+        // ─── Pause state ────────────────────────────────────────────────────
+        let paused = Self::is_paused(env.clone());
+
+        // ─── Oracle liveness ────────────────────────────────────────────────
+        let heartbeat_key = DataKey::OracleHeartbeat;
+        Self::_extend_persistent_ttl(&env, &heartbeat_key);
+        let (oracle_live, oracle_status) =
+            match env.storage().persistent().get::<_, OracleHeartbeatRecord>(&heartbeat_key) {
+                None => (false, 3u32),
+                Some(record) => {
+                    if record.status == 2 {
+                        (false, record.status)
+                    } else {
+                        let threshold_key = DataKey::OracleStaleThreshold;
+                        Self::_extend_persistent_ttl(&env, &threshold_key);
+                        let threshold: u64 = env
+                            .storage()
+                            .persistent()
+                            .get(&threshold_key)
+                            .unwrap_or(DEFAULT_ORACLE_STALE_THRESHOLD);
+                        let live = ledger_timestamp <= record.timestamp.saturating_add(threshold);
+                        (live, record.status)
+                    }
+                }
+            };
+
+        // ─── Active round phase ─────────────────────────────────────────────
+        let (has_active_round, active_round_phase) =
+            match env.storage().persistent().get::<_, Round>(&DataKey::ActiveRound) {
+                None => (false, 0u32),
+                Some(round) => {
+                    let phase = if ledger_sequence < round.bet_end_ledger {
+                        1u32
+                    } else if ledger_sequence < round.end_ledger {
+                        2u32
+                    } else {
+                        3u32
+                    };
+                    (true, phase)
+                }
+            };
+
+        // ─── Schema version ─────────────────────────────────────────────────
+        let schema_version = Self::_schema_version(&env).unwrap_or(1);
+
+        // ─── Composite status code ──────────────────────────────────────────
+        let mut issues: u32 = 0;
+        if paused {
+            issues += 1;
+        }
+        if !oracle_live {
+            issues += 1;
+        }
+        if has_active_round && active_round_phase == 3 {
+            issues += 1;
+        }
+
+        let status_code = if paused {
+            1u32 // PAUSED
+        } else if issues > 1 {
+            5u32 // MULTIPLE_ISSUES
+        } else if !oracle_live {
+            2u32 // ORACLE_STALE
+        } else if has_active_round && active_round_phase == 3 {
+            3u32 // ROUND_STALE
+        } else if !has_active_round {
+            4u32 // NO_ACTIVE_ROUND
+        } else {
+            0u32 // HEALTHY
+        };
+
+        ProtocolHealthStatus {
+            paused,
+            oracle_live,
+            oracle_status,
+            has_active_round,
+            active_round_phase,
+            schema_version,
+            ledger_sequence,
+            ledger_timestamp,
+            status_code,
+        }
     }
 
     /// Returns the configured oracle stale threshold, or the default (3600 s) if not set.

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -21,6 +21,6 @@ pub use contract::VirtualTokenContract;
 pub use errors::ContractError;
 pub use types::{
     ArchivedRoundSummary, BetSide, ConfigChangeKind, ConfigChangePayload, DataKey,
-    PendingConfigChange, PrecisionCommitment, PrecisionPrediction, Round, RoundArchiveStatus,
-    UserPosition, UserStats,
+    PendingConfigChange, PrecisionCommitment, PrecisionPrediction, ProtocolHealthStatus, Round,
+    RoundArchiveStatus, UserPosition, UserStats,
 };

--- a/contracts/src/tests/pause.rs
+++ b/contracts/src/tests/pause.rs
@@ -107,7 +107,73 @@ fn test_mutations_fail_while_paused() {
 }
 
 #[test]
-fn test_mint_initial_fails_while_paused() {
+fn test_protocol_health_paused() {
+    let env = Env::default();
+    let (client, _cid, _admin, _oracle) = setup_contract(&env);
+
+    // Not paused → status depends on other state; pause to verify status_code=1
+    client.pause_contract();
+
+    let health = client.get_protocol_health();
+    assert!(health.paused);
+    assert_eq!(health.status_code, 1); // PAUSED
+}
+
+#[test]
+fn test_protocol_health_not_paused_healthy() {
+    let env = Env::default();
+    let (client, contract_id, _admin, oracle) = setup_contract(&env);
+    let user = Address::generate(&env);
+
+    // With oracle heartbeat active + no active round → NO_ACTIVE_ROUND
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    let health = client.get_protocol_health();
+    assert!(!health.paused);
+    assert!(health.oracle_live);
+    assert!(!health.has_active_round);
+    assert_eq!(health.status_code, 4); // NO_ACTIVE_ROUND
+
+    // Create round → should become HEALTHY (betting phase)
+    client.mint_initial(&user);
+    client.create_round(&1_0000000, &None);
+
+    let health = client.get_protocol_health();
+    assert!(!health.paused);
+    assert!(health.oracle_live);
+    assert!(health.has_active_round);
+    assert_eq!(health.active_round_phase, 1); // betting
+    assert_eq!(health.status_code, 0); // HEALTHY
+}
+
+#[test]
+fn test_protocol_health_oracle_stale() {
+    let env = Env::default();
+    let (client, _cid, _admin, _oracle) = setup_contract(&env);
+
+    // Heartbeat at t=0
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Advance past threshold
+    env.ledger().with_mut(|li| {
+        li.timestamp = 4000;
+    });
+
+    let health = client.get_protocol_health();
+    assert!(!health.paused);
+    assert!(!health.oracle_live);
+    assert_eq!(health.oracle_status, 0); // stored as active, but stale
+    assert_eq!(health.status_code, 2); // ORACLE_STALE
+}
+
+#[test]
+fn test_protocol_health_mint_initial_fails_while_paused() {
     let env = Env::default();
     let (client, _cid, _admin, _oracle) = setup_contract(&env);
     let user = Address::generate(&env);

--- a/contracts/src/tests/security.rs
+++ b/contracts/src/tests/security.rs
@@ -898,3 +898,182 @@ fn test_resolve_round_both_network_and_contract_wrong() {
     });
     assert_eq!(result, Err(Ok(ContractError::OracleNetworkMismatch)));
 }
+
+// ─── Protocol health endpoint tests ──────────────────────────────────────────
+
+#[test]
+fn test_protocol_health_no_heartbeat_unknown_oracle() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // No heartbeat recorded → oracle_status=3, oracle_live=false
+    let health = client.get_protocol_health();
+    assert_eq!(health.oracle_status, 3); // unknown
+    assert!(!health.oracle_live);
+    assert!(!health.has_active_round);
+    assert_eq!(health.status_code, 2); // ORACLE_STALE
+    assert!(health.ledger_sequence > 0);
+}
+
+#[test]
+fn test_protocol_health_oracle_offline() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // Record offline heartbeat
+    env.ledger().with_mut(|li| {
+        li.timestamp = 500;
+    });
+    client.update_oracle_heartbeat(&2u32); // offline
+
+    let health = client.get_protocol_health();
+    assert!(!health.oracle_live);
+    assert_eq!(health.oracle_status, 2); // offline
+    assert_eq!(health.status_code, 2); // ORACLE_STALE
+}
+
+#[test]
+fn test_protocol_health_round_resolvable_stale() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.create_round(&1_0000000, &None);
+
+    // Advance past end_ledger so round is resolvable
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 30;
+        li.timestamp = 100;
+    });
+
+    // Keep oracle alive
+    client.update_oracle_heartbeat(&0u32);
+
+    let health = client.get_protocol_health();
+    assert!(health.has_active_round);
+    assert_eq!(health.active_round_phase, 3); // resolvable
+    assert_eq!(health.status_code, 3); // ROUND_STALE
+}
+
+#[test]
+fn test_protocol_health_multiple_issues() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.create_round(&1_0000000, &None);
+
+    // No heartbeat (oracle unknown) + round past end_ledger → multiple issues
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 30;
+        li.timestamp = 100;
+    });
+
+    let health = client.get_protocol_health();
+    assert!(!health.oracle_live);
+    assert!(health.has_active_round);
+    assert_eq!(health.active_round_phase, 3); // resolvable
+    assert_eq!(health.status_code, 5); // MULTIPLE_ISSUES
+}
+
+#[test]
+fn test_protocol_health_schema_version_present() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    let health = client.get_protocol_health();
+    assert_eq!(health.schema_version, 2);
+}
+
+#[test]
+fn test_protocol_health_round_betting_phase() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&user);
+
+    // Oracle heartbeat active
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Create round at ledger 6
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 6;
+    });
+    client.create_round(&1_0000000, &None);
+
+    // Still in betting window (ledger 6, bet_end = 6+6=12)
+    let health = client.get_protocol_health();
+    assert!(health.has_active_round);
+    assert_eq!(health.active_round_phase, 1); // betting
+    assert_eq!(health.status_code, 0); // HEALTHY
+}
+
+#[test]
+fn test_protocol_health_round_running_phase() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&user);
+
+    // Oracle heartbeat active
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Create round at ledger 0
+    client.create_round(&1_0000000, &None);
+    // Default windows: bet=6, run=12
+    // bet_end = 6, end = 12
+
+    // Advance into running phase (past bet_end, before end)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 8;
+    });
+
+    let health = client.get_protocol_health();
+    assert!(health.has_active_round);
+    assert_eq!(health.active_round_phase, 2); // running
+    assert_eq!(health.status_code, 0); // HEALTHY
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -230,6 +230,62 @@ pub enum RoundArchiveStatus {
     FallbackRefund = 2,
 }
 
+/// Composite protocol health status returned by `get_protocol_health`.
+///
+/// Designed for operators to poll a single endpoint instead of stitching
+/// together multiple read-only calls.
+///
+/// ## Status code → alert severity mapping
+///
+/// | code | label           | severity | meaning                                   |
+/// |------|-----------------|----------|-------------------------------------------|
+/// | 0    | HEALTHY         | none     | All subsystems nominal                    |
+/// | 1    | PAUSED          | critical | Contract is emergency-paused               |
+/// | 2    | ORACLE_STALE    | warning  | Oracle heartbeat is stale or offline      |
+/// | 3    | ROUND_STALE     | warning  | Round is past its end ledger but unresolved|
+/// | 4    | NO_ACTIVE_ROUND | info     | No round currently active (idle protocol) |
+/// | 5    | MULTIPLE_ISSUES | critical | Two or more issues detected simultaneously|
+///
+/// ## Phase codes (`active_round_phase`)
+///
+/// | phase | meaning                                           |
+/// |-------|---------------------------------------------------|
+/// | 0     | No active round                                   |
+/// | 1     | Betting open (`ledger < bet_end_ledger`)           |
+/// | 2     | Running / reveal window (`bet_end_ledger ≤ ledger < end_ledger`) |
+/// | 3     | Resolvable (`ledger ≥ end_ledger`)                |
+///
+/// ## Oracle status codes (`oracle_status`)
+///
+/// | code | meaning                                |
+/// |------|----------------------------------------|
+/// | 0    | Active (healthy heartbeat)             |
+/// | 1    | Degraded (heartbeat marked degraded)   |
+/// | 2    | Offline (heartbeat marked offline)     |
+/// | 3    | Unknown (no heartbeat record stored)   |
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProtocolHealthStatus {
+    /// Whether the contract is emergency-paused (`Paused == true`)
+    pub paused: bool,
+    /// Whether the oracle heartbeat is non-stale and not offline
+    pub oracle_live: bool,
+    /// Raw oracle heartbeat status (0=active, 1=degraded, 2=offline, 3=unknown)
+    pub oracle_status: u32,
+    /// Whether a round is currently active
+    pub has_active_round: bool,
+    /// Current round phase (0=no_round, 1=betting, 2=running, 3=resolvable)
+    pub active_round_phase: u32,
+    /// On-chain storage schema version
+    pub schema_version: u32,
+    /// Ledger sequence at which this health snapshot was taken
+    pub ledger_sequence: u32,
+    /// Ledger timestamp at which this health snapshot was taken
+    pub ledger_timestamp: u64,
+    /// Composite status code (see mapping table above)
+    pub status_code: u32,
+}
+
 /// Compact historical round summary persisted after resolve or cancel.
 ///
 /// Designed for explorer/analytics queries without replaying events.


### PR DESCRIPTION
## Summary

Added `get_protocol_health`, a read-only no-auth endpoint returning a `ProtocolHealthStatus` struct that aggregates pause state, oracle liveness (`active`/`degraded`/`offline`/`unknown`), active round phase (`no_round`/`betting`/`running`/`resolvable`), schema version, ledger context, and a composite `status_code` (0=HEALTHY through 5=MULTIPLE_ISSUES). Struct and severity mappings documented in `types.rs`. 10 new tests across `pause.rs` and `security.rs` cover all status branches including paused, oracle stale/offline/unknown, round resolvable stale, multiple simultaneous issues, and both betting/running phases. Pre-existing compilation errors (Soroban SDK version mismatch between `Cargo.toml` and `Cargo.lock`) are unrelated to these changes.

## Linked issues

- Closes #165 

## Validation

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `cd bindings && npm ci && npm run build`

## Governance checklist

- [ ] I reviewed `CONTRIBUTING.md` for workflow expectations
- [ ] I checked `CODEOWNERS` impact for touched paths
- [ ] I followed `SUPPORT.md` disclosure guidance for any security-sensitive change
