### PR TITLE
Add snapshot policy and update script for snapshot management

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,8 @@
 - [ ] I reviewed `CONTRIBUTING.md` for workflow expectations
 - [ ] I checked `CODEOWNERS` impact for touched paths
 - [ ] I followed `SUPPORT.md` disclosure guidance for any security-sensitive change
+
+## Snapshot policy
+
+- [ ] If snapshot files under `contracts/test_snapshots/` changed, I reviewed the diff and confirmed every change is intentional
+- [ ] If snapshot drift was reported in CI, I either regenerated snapshots or marked the drift as expected in the PR description

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,20 @@ jobs:
       - name: Benchmark report (cost/gas regression guardrails)
         run: cargo test --package xelma-contract cost_benchmarks --locked -- --nocapture
 
+      - name: Snapshot drift detection
+        run: |
+          if [ -d "contracts/test_snapshots" ] && ls contracts/test_snapshots/*.snap 1>/dev/null 2>&1; then
+            echo "--- Snapshot drift check ---"
+            echo "Snapshot golden files exist. To regenerate intentionally:"
+            echo "  ./scripts/update_snapshots.sh"
+            echo ""
+            echo "If you did not intend to change snapshots, check for accidental"
+            echo "storage or event mutations in your branch."
+            echo "---"
+          else
+            echo "No snapshot golden files to check."
+          fi
+
       - name: Run cargo clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,33 @@ sent back for detail before they are picked up.
 
 Before opening a PR, consult [`docs/CONTRIBUTOR_TASK_MATRIX.md`](./docs/CONTRIBUTOR_TASK_MATRIX.md) for task-type-specific test and evidence requirements.
 
+## Snapshot Tests
+
+The project uses storage-snapshot golden files (`contracts/test_snapshots/`) to detect
+unintentional changes to contract state, event emissions, and error behavior.
+
+### When snapshots should change
+
+- You modified contract logic, storage keys, event payloads, or error variants.
+- You made non-semantic refactors that still cause snapshot output to differ (rare).
+
+### When snapshots should NOT change
+
+- Your change is in an unrelated module, test infrastructure, or documentation.
+- CI reports snapshot drift that you did not intend — investigate before regenerating.
+
+### Updating snapshots
+
+After an intentional behavior change, regenerate golden files from the repo root:
+
+```bash
+./scripts/update_snapshots.sh
+```
+
+Then review the diff, run the full suite, and commit the updated snapshots alongside
+your logic change. See [`contracts/test_snapshots/README.md`](./contracts/test_snapshots/README.md)
+for a step-by-step guide.
+
 ## Security Checks (local)
 
 The CI `security-audit` job runs two checks that maintainers and contributors can reproduce locally.

--- a/scripts/update_snapshots.sh
+++ b/scripts/update_snapshots.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# update_snapshots.sh — Regenerate snapshot golden files deterministically.
+#
+# Usage:
+#   ./scripts/update_snapshots.sh
+#
+# This script:
+#   1. Sets SNAPSHOT_UPDATE=1 so snapshot tests overwrite golden files.
+#   2. Runs snapshot-related tests under contracts/.
+#   3. Reports which files changed.
+#
+# Run from the repository root.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SNAPSHOT_DIR="$REPO_ROOT/contracts/test_snapshots"
+
+echo "============================================"
+echo "  Snapshot Golden Update"
+echo "============================================"
+echo ""
+
+# Ensure the snapshot directory exists
+mkdir -p "$SNAPSHOT_DIR"
+
+# Record current snapshot hashes before regeneration
+echo "[1/3] Recording current snapshot state …"
+PRE_HASH=""
+if ls "$SNAPSHOT_DIR"/*.snap 1>/dev/null 2>&1; then
+  PRE_HASH=$(sha256sum "$SNAPSHOT_DIR"/*.snap | sort)
+fi
+
+# Run snapshot tests with update mode enabled
+echo "[2/3] Regenerating snapshots …"
+SNAPSHOT_UPDATE=1 \
+  cargo test --package xelma-contract --locked -- --nocapture \
+  2>&1 | tail -20
+
+# Report what changed
+echo ""
+echo "[3/3] Checking for changes …"
+POST_HASH=""
+if ls "$SNAPSHOT_DIR"/*.snap 1>/dev/null 2>&1; then
+  POST_HASH=$(sha256sum "$SNAPSHOT_DIR"/*.snap | sort)
+fi
+
+if [[ "$PRE_HASH" != "$POST_HASH" ]]; then
+  echo "  Snapshot files updated:"
+  (diff <(echo "$PRE_HASH") <(echo "$POST_HASH") 2>/dev/null || true) | grep '^[<>]' || echo "  (new snapshots created)"
+  echo ""
+  echo "  Review the diff with: git diff $SNAPSHOT_DIR"
+else
+  echo "  No snapshot changes detected."
+fi
+
+echo ""
+echo "============================================"
+echo "  Done. Run 'cargo test --workspace' to verify."
+echo "============================================"


### PR DESCRIPTION
## Summary

Document and automate the snapshot golden update workflow so contributors can maintain `contracts/test_snapshots/` safely when intentional behavior changes occur.

## Linked issues

- Closes #174

## Changes

### New files

- **`contracts/test_snapshots/README.md`** — documents when snapshots should/shouldn't change and provides a step-by-step update process
- **`scripts/update_snapshots.sh`** — one-command snapshot refresh script that sets `SNAPSHOT_UPDATE=1` and regenerates golden files deterministically

### Modified files

- **`CONTRIBUTING.md`** — added "Snapshot Tests" section explaining the golden file workflow, when to update, and how to use the refresh script
- **`.github/PULL_REQUEST_TEMPLATE.md`** — added "Snapshot policy" section with checkboxes for reviewing snapshot diffs and handling CI drift
- **`.github/workflows/ci.yml`** — added "Snapshot drift detection" step in the `rust-test` job that reminds contributors how to regenerate when golden files are present

## Validation

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `cd bindings && npm ci && npm run build`
