### PR TITLE
Add SPDX license headers to contract Rust sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,31 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
 
+  license-header-check:
+    name: SPDX License Headers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check SPDX headers in contract source files
+        run: |
+          missing=0
+          while IFS= read -r -d '' file; do
+            if ! head -n 5 "$file" | grep -q 'SPDX-License-Identifier'; then
+              echo "Missing header: $file"
+              missing=$((missing + 1))
+            fi
+          done < <(find contracts/src -name '*.rs' -print0)
+
+          if [ "$missing" -gt 0 ]; then
+            echo ""
+            echo "FAIL: $missing file(s) are missing SPDX license headers."
+            echo "Run 'scripts/add_spdx_headers.sh' to fix."
+            exit 1
+          fi
+          echo "All contract source files have SPDX license headers."
+
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
@@ -380,19 +405,20 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [rust-test, contract-build, bindings-test, bindings-build, parity-check, coverage, format-check, security-audit]
+    needs: [rust-test, contract-build, bindings-test, bindings-build, parity-check, coverage, format-check, license-header-check, security-audit]
     if: always()
     steps:
       - name: Check all jobs status
         run: |
-          if [ "${{ needs.rust-test.result }}" != "success" ] || \
-             [ "${{ needs.contract-build.result }}" != "success" ] || \
-             [ "${{ needs.bindings-test.result }}" != "success" ] || \
-             [ "${{ needs.bindings-build.result }}" != "success" ] || \
-             [ "${{ needs.parity-check.result }}" != "success" ] || \
-             [ "${{ needs.coverage.result }}" != "success" ] || \
-             [ "${{ needs.format-check.result }}" != "success" ] || \
-             [ "${{ needs.security-audit.result }}" != "success" ]; then
+           if [ "${{ needs.rust-test.result }}" != "success" ] || \
+              [ "${{ needs.contract-build.result }}" != "success" ] || \
+              [ "${{ needs.bindings-test.result }}" != "success" ] || \
+              [ "${{ needs.bindings-build.result }}" != "success" ] || \
+              [ "${{ needs.parity-check.result }}" != "success" ] || \
+              [ "${{ needs.coverage.result }}" != "success" ] || \
+              [ "${{ needs.format-check.result }}" != "success" ] || \
+              [ "${{ needs.license-header-check.result }}" != "success" ] || \
+              [ "${{ needs.security-audit.result }}" != "success" ]; then
             echo "One or more CI jobs failed"
             echo "Rust Tests: ${{ needs.rust-test.result }}"
             echo "Contract Build: ${{ needs.contract-build.result }}"
@@ -401,6 +427,7 @@ jobs:
             echo "Parity Check: ${{ needs.parity-check.result }}"
             echo "Code Coverage: ${{ needs.coverage.result }}"
             echo "Format Check: ${{ needs.format-check.result }}"
+            echo "SPDX Headers: ${{ needs.license-header-check.result }}"
             echo "Security Audit: ${{ needs.security-audit.result }}"
             exit 1
           fi

--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Core contract implementation for the XLM Price Prediction Market.
 
 use soroban_sdk::xdr::ToXdr;

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Contract error types for the XLM Price Prediction Market.
 
 use soroban_sdk::contracterror;

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #![no_std]
 //! # XLM Price Prediction Market
 //!

--- a/contracts/src/tests/betting.rs
+++ b/contracts/src/tests/betting.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for bet placement and validation.
 
 use super::config_helpers::{apply_max_stake, apply_max_user_exposure};

--- a/contracts/src/tests/cei_ordering.rs
+++ b/contracts/src/tests/cei_ordering.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! CEI (Checks-Effects-Interactions) ordering regression tests.
 //!
 //! These tests verify that the two CEI fixes applied in issue #195 hold

--- a/contracts/src/tests/chaos_recovery.rs
+++ b/contracts/src/tests/chaos_recovery.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Chaos and recovery tests for interrupted lifecycle actions (Issue #122).
 //!
 //! Each scenario models a failure-like condition or unusual execution sequence and

--- a/contracts/src/tests/commit_reveal_e2e.rs
+++ b/contracts/src/tests/commit_reveal_e2e.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! End-to-end commit-reveal precision lifecycle integration suite (Issue #171).
 //!
 //! This module exercises the full **commit → reveal → resolve → claim**

--- a/contracts/src/tests/config_helpers.rs
+++ b/contracts/src/tests/config_helpers.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Helpers to apply timelocked config immediately in tests.
 
 use crate::contract::VirtualTokenContractClient;

--- a/contracts/src/tests/config_timelock.rs
+++ b/contracts/src/tests/config_timelock.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for timelocked critical config changes (governance safety).
 
 use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};

--- a/contracts/src/tests/cost_benchmarks.rs
+++ b/contracts/src/tests/cost_benchmarks.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Gas/cost benchmark baselines with regression guardrails (Issue #121).
 //!
 //! These benchmarks measure the host CPU-instruction and memory cost of each

--- a/contracts/src/tests/edge_cases.rs
+++ b/contracts/src/tests/edge_cases.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for boundary conditions and unusual scenarios.
 
 use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};

--- a/contracts/src/tests/event_coverage.rs
+++ b/contracts/src/tests/event_coverage.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Event coverage and completeness verification tests (Issue #117).
 
 use super::config_helpers::apply_windows;

--- a/contracts/src/tests/guard_tests.rs
+++ b/contracts/src/tests/guard_tests.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for the single-active-round invariant guard (assert_no_active_round).
 //!
 //! Success path: no active round → create_round proceeds, storage updated.

--- a/contracts/src/tests/initialization.rs
+++ b/contracts/src/tests/initialization.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for contract initialization and token minting.
 
 use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};

--- a/contracts/src/tests/invariant_harness.rs
+++ b/contracts/src/tests/invariant_harness.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Differential invariant test harness using a reference model.
 
 use proptest::prelude::*;

--- a/contracts/src/tests/lifecycle.rs
+++ b/contracts/src/tests/lifecycle.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for round creation and full round lifecycle scenarios.
 
 use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};

--- a/contracts/src/tests/migration_versioning.rs
+++ b/contracts/src/tests/migration_versioning.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for schema versioning and migration guards.
 
 use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Test modules for the XLM Price Prediction Market contract.
 
 mod betting;

--- a/contracts/src/tests/mode_tests.rs
+++ b/contracts/src/tests/mode_tests.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for round mode flag and separate prediction storage.
 
 use super::config_helpers::{apply_max_stake, apply_max_user_exposure, apply_windows};

--- a/contracts/src/tests/overflow_tests.rs
+++ b/contracts/src/tests/overflow_tests.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Overflow boundary tests for payout arithmetic in claim_winnings and helpers.
 //!
 //! Each test targets a specific arithmetic branch:

--- a/contracts/src/tests/pause.rs
+++ b/contracts/src/tests/pause.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for emergency pause and recovery controls.
 
 use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};

--- a/contracts/src/tests/property_invariants.rs
+++ b/contracts/src/tests/property_invariants.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Property-based tests for payout invariants.
 //!
 //! These tests exercise randomized scenarios to ensure core invariants such as:

--- a/contracts/src/tests/reference_model.rs
+++ b/contracts/src/tests/reference_model.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Simplified reference model for contract state used in invariant testing.
 
 use std::collections::HashMap;

--- a/contracts/src/tests/resolution.rs
+++ b/contracts/src/tests/resolution.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for round resolution and winnings distribution.
 
 use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};

--- a/contracts/src/tests/security.rs
+++ b/contracts/src/tests/security.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Security tests for Oracle data freshness and round validation.
 
 use super::config_helpers::{apply_oracle_max_deviation_bps, apply_oracle_stale_threshold};

--- a/contracts/src/tests/storage_benchmarks.rs
+++ b/contracts/src/tests/storage_benchmarks.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Benchmark-style tests for the indexed storage layout.
 //!
 //! These tests assert on the *operation count* of each core path

--- a/contracts/src/tests/ttl_tests.rs
+++ b/contracts/src/tests/ttl_tests.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for storage TTL rent policy enforcement (Issue #142).
 
 use super::config_helpers::apply_max_stake;

--- a/contracts/src/tests/windows.rs
+++ b/contracts/src/tests/windows.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Tests for configurable betting and execution windows.
 
 use super::config_helpers::apply_windows;

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Type definitions for the XLM Price Prediction Market.
 
 use soroban_sdk::{contracttype, Address, BytesN};

--- a/scripts/add_spdx_headers.sh
+++ b/scripts/add_spdx_headers.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# add_spdx_headers.sh — Add SPDX license headers to Soroban contract Rust source files.
+#
+# Finds all .rs files under contracts/src/, checks whether an SPDX header already
+# exists, and prepends one if missing. Safe to run multiple times — headers are
+# never duplicated.
+
+set -euo pipefail
+
+HEADER='// SPDX-License-Identifier: MIT'
+SEARCH_PATTERN='SPDX-License-Identifier'
+TARGET_DIR='contracts/src'
+
+cwd="${BASH_SOURCE[0]%/*}"
+repo_root="$(cd "$cwd/.." && pwd)"
+
+added=0
+skipped=0
+errors=0
+
+while IFS= read -r -d '' file; do
+    if head -n 5 "$file" | grep -q "$SEARCH_PATTERN"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    tmp="$(mktemp)"
+    printf '%s\n' "$HEADER" > "$tmp"
+    cat "$file" >> "$tmp"
+    mv "$tmp" "$file"
+    added=$((added + 1))
+    echo "  + $file"
+done < <(find "$repo_root/$TARGET_DIR" -name '*.rs' -print0)
+
+echo ""
+echo "Done — ${added} header(s) added, ${skipped} already present, ${errors} error(s)."


### PR DESCRIPTION
Closes #192

Summary:
Adds consistent SPDX license headers across all contract Rust source files.

Changes:

- Added MIT SPDX headers to contracts/src/**/*.rs
- Added scripts/add_spdx_headers.sh helper
- Added CI validation to prevent missing headers in future changes

Implementation details:

- No functional code changes
- Script is idempotent and safe to rerun
- CI checks only relevant contract source files

Validation:

- Verified all contract Rust files contain SPDX headers
- Confirmed CI catches missing headers
- Existing contract behavior unchanged