### PR TITLE
Add typed helper functions and integration tests for wallet operations

### DIFF
--- a/bindings/README.md
+++ b/bindings/README.md
@@ -77,3 +77,81 @@ console.log(formatContractError(9) ?? "Unknown error")
 Use `decodeContractError` to surface contextual information in your wallet or
 bot, and fall back to `"Unknown contract error (code N)"` for codes that the
 current bindings do not yet recognise.
+
+# High-level helpers
+
+The `@xelma/bindings/helpers` module provides typed convenience wrappers
+around the generated client for common wallet flows.
+
+## `mintIfNeeded`
+
+Checks a user's vXLM balance and mints initial tokens if the balance is zero.
+One-time per user (enforced by the contract).
+
+```ts
+import { mintIfNeeded } from "@xelma/bindings/helpers"
+
+const { minted, balance } = await mintIfNeeded(client, "GABCDEF123...")
+if (minted) {
+  console.log(`Minted initial tokens. Balance: ${balance}`)
+}
+```
+
+## `placeBetChecked`
+
+Places a bet after running pre-flight validation:
+1. Contract is not paused
+2. An active round exists
+3. User has sufficient balance
+
+Throws typed exceptions for known failure modes.
+
+```ts
+import { placeBetChecked } from "@xelma/bindings/helpers"
+
+try {
+  const tx = await placeBetChecked(client, {
+    user: "GABCDEF123...",
+    amount: 500_000_000n,   // 50 vXLM (7-digit precision)
+    side: { tag: "Up", values: undefined },
+  })
+  console.log("Bet placed!")
+} catch (err) {
+  if (err instanceof ContractPausedError) {
+    console.log("Betting is paused right now.")
+  } else if (err instanceof InsufficientBalanceError) {
+    console.log("Not enough vXLM — try minting first.")
+  } else if (err instanceof NoActiveRoundError) {
+    console.log("No round is currently active.")
+  } else {
+    console.error("Unexpected error:", err)
+  }
+}
+```
+
+## `claimIfPending`
+
+Checks for pending winnings and claims them if any exist.
+
+```ts
+import { claimIfPending } from "@xelma/bindings/helpers"
+
+const { claimed, amount } = await claimIfPending(client, "GABCDEF123...")
+if (claimed) {
+  console.log(`Claimed ${amount} vXLM`)
+}
+```
+
+## Error reference
+
+| Exception                  | Contract code | Meaning                          |
+|----------------------------|---------------|----------------------------------|
+| `InsufficientBalanceError` | 9             | Not enough vXLM to place bet     |
+| `NoActiveRoundError`       | 7             | No round is currently active     |
+| `ContractPausedError`      | 22            | Contract paused for maintenance  |
+| `AlreadyBetError`          | 10            | User already bet in this round   |
+| `StakeExceedsMaxError`     | 28            | Bet exceeds the max stake cap    |
+| `ExposureCapExceededError` | 29            | User exposure exceeds round cap  |
+
+All typed exceptions extend `XelmaError` (which extends `Error`), so you
+can catch specific types or the base class.

--- a/bindings/package-lock.json
+++ b/bindings/package-lock.json
@@ -534,9 +534,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -551,9 +548,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -568,9 +562,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -585,9 +576,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -602,9 +590,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -619,9 +604,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -636,9 +618,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,9 +632,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -670,9 +646,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -687,9 +660,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -704,9 +674,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -721,9 +688,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,9 +702,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -3,7 +3,10 @@
   "version": "1.1.0",
   "description": "TypeScript bindings for the Xelma on-chain prediction market smart contract",
   "type": "module",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./helpers": "./dist/helpers.js"
+  },
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
@@ -17,6 +20,7 @@
     "test:parity": "node src/parity.js",
     "test:errors": "node tests/contract-error-parity.test.js",
     "test:wasm": "vitest run tests/wasm-parity.test.js",
+    "test:integration": "vitest run tests/integration.test.ts",
     "prepublishOnly": "npm run build && npm run test:parity && npm run test:errors"
   },
   "dependencies": {

--- a/bindings/src/helpers.ts
+++ b/bindings/src/helpers.ts
@@ -1,0 +1,216 @@
+import { Client } from "./index.js";
+import type {
+  AssembledTransaction,
+  MethodOptions,
+} from "@stellar/stellar-sdk/contract";
+import type { i128 } from "@stellar/stellar-sdk/contract";
+
+// Re-export BetSide from the generated client for convenience
+import type { BetSide } from "./index.js";
+
+// ─── Typed Exceptions ──────────────────────────────────────────
+
+export class XelmaError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: number,
+    public readonly variant?: string,
+  ) {
+    super(message);
+    this.name = "XelmaError";
+  }
+}
+
+export class InsufficientBalanceError extends XelmaError {
+  constructor() {
+    super("User has insufficient vXLM balance to place a bet", 9, "InsufficientBalance");
+    this.name = "InsufficientBalanceError";
+  }
+}
+
+export class NoActiveRoundError extends XelmaError {
+  constructor() {
+    super("No active round is available for betting", 7, "NoActiveRound");
+    this.name = "NoActiveRoundError";
+  }
+}
+
+export class ContractPausedError extends XelmaError {
+  constructor() {
+    super("Contract is currently paused — no betting allowed", 22, "ContractPaused");
+    this.name = "ContractPausedError";
+  }
+}
+
+export class AlreadyBetError extends XelmaError {
+  constructor() {
+    super("User has already placed a bet in the current round", 10, "AlreadyBet");
+    this.name = "AlreadyBetError";
+  }
+}
+
+export class StakeExceedsMaxError extends XelmaError {
+  constructor() {
+    super("Bet amount exceeds the configured maximum stake", 28, "StakeExceedsMax");
+    this.name = "StakeExceedsMaxError";
+  }
+}
+
+export class ExposureCapExceededError extends XelmaError {
+  constructor() {
+    super("User's cumulative exposure in this round exceeds the configured cap", 29, "ExposureCapExceeded");
+    this.name = "ExposureCapExceededError";
+  }
+}
+
+// ─── Error Mapping ─────────────────────────────────────────────
+
+const ERROR_CODE_TO_CLASS: Record<number, new () => XelmaError> = {
+  7: NoActiveRoundError,
+  9: InsufficientBalanceError,
+  10: AlreadyBetError,
+  22: ContractPausedError,
+  28: StakeExceedsMaxError,
+  29: ExposureCapExceededError,
+};
+
+/**
+ * Wraps an unknown error thrown from a Soroban RPC call into a typed
+ * `XelmaError` subclass when the error contains a recognized contract
+ * error code.  Unrecognized / non-contract errors pass through unchanged.
+ */
+export function wrapContractError(err: unknown): Error {
+  if (err instanceof XelmaError) return err;
+
+  let code: number | undefined;
+
+  if (err && typeof err === "object") {
+    if ("code" in err && typeof (err as Record<string, unknown>).code === "number") {
+      code = (err as Record<string, number>).code;
+    }
+    if (code === undefined && "message" in err) {
+      const msg = String((err as Record<string, unknown>).message);
+      const match = msg.match(/contract error code (\d+)/);
+      if (match) code = parseInt(match[1], 10);
+    }
+  }
+
+  if (code !== undefined && ERROR_CODE_TO_CLASS[code]) {
+    return new (ERROR_CODE_TO_CLASS[code])();
+  }
+
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+// ─── Mint Helper ───────────────────────────────────────────────
+
+export interface MintResult {
+  minted: boolean;
+  balance: i128;
+}
+
+/**
+ * Checks a user's vXLM balance and mints the initial 1000 vXLM if the
+ * balance is zero.  The contract enforces one-time mint per user.
+ *
+ * @example
+ * const { minted, balance } = await mintIfNeeded(client, "GABCDEF123...")
+ * if (minted) console.log(`Minted initial tokens. New balance: ${balance}`)
+ */
+export async function mintIfNeeded(
+  client: Client,
+  user: string,
+  options?: MethodOptions,
+): Promise<MintResult> {
+  const { result: balance } = await client.balance({ user }, options);
+
+  if (BigInt(balance) > 0n) {
+    return { minted: false, balance };
+  }
+
+  await client.mint_initial({ user }, options).then((tx) => tx.signAndSend());
+
+  const { result: newBalance } = await client.balance({ user }, options);
+  return { minted: true, balance: newBalance };
+}
+
+// ─── Bet Helper ────────────────────────────────────────────────
+
+export interface PlaceBetParams {
+  user: string;
+  amount: i128;
+  side: BetSide;
+}
+
+/**
+ * Places a bet with pre-flight validation:
+ *   1. Contract is not paused
+ *   2. An active round exists
+ *   3. User has sufficient vXLM balance
+ *
+ * Throws typed `XelmaError` subclasses for known failure modes so
+ * integrators can handle errors by type rather than parsing raw codes.
+ *
+ * @example
+ * import { placeBetChecked } from "@xelma/bindings/helpers"
+ *
+ * await placeBetChecked(client, {
+ *   user: "GABCDEF123...",
+ *   amount: 500_000_000n,  // 50 vXLM (7-digit precision)
+ *   side: { tag: "Up", values: undefined },
+ * })
+ */
+export async function placeBetChecked(
+  client: Client,
+  params: PlaceBetParams,
+  options?: MethodOptions,
+) {
+  const { user, amount, side } = params;
+
+  const { result: paused } = await client.is_paused(options);
+  if (paused) throw new ContractPausedError();
+
+  const { result: activeRound } = await client.get_active_round(options);
+  if (!activeRound) throw new NoActiveRoundError();
+
+  const { result: balance } = await client.balance({ user }, options);
+  if (BigInt(balance) < BigInt(amount)) throw new InsufficientBalanceError();
+
+  const betTx = await client.place_bet({ user, amount, side }, options);
+  try {
+    return await betTx.signAndSend();
+  } catch (err) {
+    throw wrapContractError(err);
+  }
+}
+
+// ─── Claim Helper ──────────────────────────────────────────────
+
+export interface ClaimResult {
+  claimed: boolean;
+  amount?: i128;
+}
+
+/**
+ * Checks for pending winnings and automatically claims them if the
+ * balance is greater than zero.
+ *
+ * @example
+ * const { claimed, amount } = await claimIfPending(client, "GABCDEF123...")
+ * if (claimed) console.log(`Claimed ${amount} vXLM`)
+ */
+export async function claimIfPending(
+  client: Client,
+  user: string,
+  options?: MethodOptions,
+): Promise<ClaimResult> {
+  const { result: pending } = await client.get_pending_winnings({ user }, options);
+
+  if (BigInt(pending) > 0n) {
+    const claimTx = await client.claim_winnings({ user }, options);
+    await claimTx.signAndSend();
+    return { claimed: true, amount: pending };
+  }
+
+  return { claimed: false };
+}

--- a/bindings/tests/integration.test.ts
+++ b/bindings/tests/integration.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  mintIfNeeded,
+  placeBetChecked,
+  claimIfPending,
+  XelmaError,
+  InsufficientBalanceError,
+  NoActiveRoundError,
+  ContractPausedError,
+  AlreadyBetError,
+  StakeExceedsMaxError,
+  ExposureCapExceededError,
+  wrapContractError,
+  type MintResult,
+  type ClaimResult,
+  type PlaceBetParams,
+} from "../src/helpers.js";
+
+// ─── Helpers ───────────────────────────────────────────────────
+
+function mockTx<T>(result: T) {
+  return {
+    result,
+    signAndSend: vi.fn().mockResolvedValue({ result }),
+  };
+}
+
+function createMockClient() {
+  return {
+    balance: vi.fn(),
+    mint_initial: vi.fn(),
+    is_paused: vi.fn(),
+    get_active_round: vi.fn(),
+    place_bet: vi.fn(),
+    get_pending_winnings: vi.fn(),
+    claim_winnings: vi.fn(),
+  } as any;
+}
+
+// ─── mintIfNeeded ──────────────────────────────────────────────
+
+describe("mintIfNeeded", () => {
+  it("returns minted=false when balance > 0", async () => {
+    const client = createMockClient();
+    client.balance.mockResolvedValue(mockTx(50_000_000n));
+
+    const result = await mintIfNeeded(client, "GABC");
+    expect(result.minted).toBe(false);
+    expect(result.balance).toBe(50_000_000n);
+    expect(client.mint_initial).not.toHaveBeenCalled();
+  });
+
+  it("mints and returns minted=true when balance is 0", async () => {
+    const client = createMockClient();
+    client.balance
+      .mockResolvedValueOnce(mockTx(0n))
+      .mockResolvedValueOnce(mockTx(10_000_000_000n));
+    client.mint_initial.mockResolvedValue(mockTx(10_000_000_000n));
+
+    const result = await mintIfNeeded(client, "GABC");
+    expect(result.minted).toBe(true);
+    expect(result.balance).toBe(10_000_000_000n);
+    expect(client.mint_initial).toHaveBeenCalledWith({ user: "GABC" }, undefined);
+  });
+
+  it("forwards options to client calls", async () => {
+    const client = createMockClient();
+    client.balance
+      .mockResolvedValueOnce(mockTx(0n))
+      .mockResolvedValueOnce(mockTx(10_000_000_000n));
+    client.mint_initial.mockResolvedValue(mockTx(10_000_000_000n));
+
+    const opts = { simulate: true } as any;
+    await mintIfNeeded(client, "GABC", opts);
+    expect(client.balance).toHaveBeenCalledWith({ user: "GABC" }, opts);
+    expect(client.mint_initial).toHaveBeenCalledWith({ user: "GABC" }, opts);
+  });
+});
+
+// ─── placeBetChecked ───────────────────────────────────────────
+
+describe("placeBetChecked", () => {
+  const params: PlaceBetParams = {
+    user: "GABC",
+    amount: 500_000_000n,
+    side: { tag: "Up", values: undefined },
+  };
+
+  it("places bet when all checks pass", async () => {
+    const client = createMockClient();
+    client.is_paused.mockResolvedValue(mockTx(false));
+    client.get_active_round.mockResolvedValue(mockTx({ round_id: 1n }));
+    client.balance.mockResolvedValue(mockTx(1_000_000_000n));
+    client.place_bet.mockResolvedValue(mockTx(undefined));
+
+    const result = await placeBetChecked(client, params);
+    expect(result).toBeDefined();
+    expect(client.place_bet).toHaveBeenCalledWith(params, undefined);
+  });
+
+  it("throws ContractPausedError when paused", async () => {
+    const client = createMockClient();
+    client.is_paused.mockResolvedValue(mockTx(true));
+
+    await expect(placeBetChecked(client, params)).rejects.toThrow(ContractPausedError);
+    expect(client.place_bet).not.toHaveBeenCalled();
+  });
+
+  it("throws NoActiveRoundError when no active round", async () => {
+    const client = createMockClient();
+    client.is_paused.mockResolvedValue(mockTx(false));
+    client.get_active_round.mockResolvedValue(mockTx(null));
+
+    await expect(placeBetChecked(client, params)).rejects.toThrow(NoActiveRoundError);
+    expect(client.place_bet).not.toHaveBeenCalled();
+  });
+
+  it("throws InsufficientBalanceError when balance too low", async () => {
+    const client = createMockClient();
+    client.is_paused.mockResolvedValue(mockTx(false));
+    client.get_active_round.mockResolvedValue(mockTx({ round_id: 1n }));
+    client.balance.mockResolvedValue(mockTx(100_000_000n));
+
+    await expect(placeBetChecked(client, params)).rejects.toThrow(InsufficientBalanceError);
+    expect(client.place_bet).not.toHaveBeenCalled();
+  });
+
+  it("maps contract errors from signAndSend to typed exceptions", async () => {
+    const client = createMockClient();
+    client.is_paused.mockResolvedValue(mockTx(false));
+    client.get_active_round.mockResolvedValue(mockTx({ round_id: 1n }));
+    client.balance.mockResolvedValue(mockTx(1_000_000_000n));
+
+    const err = new Error("simulation failed: contract error code 10");
+    client.place_bet.mockResolvedValue({
+      result: undefined,
+      signAndSend: vi.fn().mockRejectedValue(err),
+    });
+
+    await expect(placeBetChecked(client, params)).rejects.toThrow(AlreadyBetError);
+  });
+});
+
+// ─── claimIfPending ────────────────────────────────────────────
+
+describe("claimIfPending", () => {
+  it("returns claimed=false when no pending winnings", async () => {
+    const client = createMockClient();
+    client.get_pending_winnings.mockResolvedValue(mockTx(0n));
+
+    const result = await claimIfPending(client, "GABC");
+    expect(result.claimed).toBe(false);
+    expect(client.claim_winnings).not.toHaveBeenCalled();
+  });
+
+  it("claims and returns claimed=true when winnings > 0", async () => {
+    const client = createMockClient();
+    client.get_pending_winnings.mockResolvedValue(mockTx(2_500_000_000n));
+    client.claim_winnings.mockResolvedValue(mockTx(2_500_000_000n));
+
+    const result = await claimIfPending(client, "GABC");
+    expect(result.claimed).toBe(true);
+    expect(result.amount).toBe(2_500_000_000n);
+    expect(client.claim_winnings).toHaveBeenCalledWith({ user: "GABC" }, undefined);
+  });
+
+  it("forwards options to client calls", async () => {
+    const client = createMockClient();
+    client.get_pending_winnings.mockResolvedValue(mockTx(1n));
+    client.claim_winnings.mockResolvedValue(mockTx(1n));
+
+    const opts = { simulate: true } as any;
+    await claimIfPending(client, "GABC", opts);
+    expect(client.get_pending_winnings).toHaveBeenCalledWith({ user: "GABC" }, opts);
+    expect(client.claim_winnings).toHaveBeenCalledWith({ user: "GABC" }, opts);
+  });
+});
+
+// ─── wrapContractError ─────────────────────────────────────────
+
+describe("wrapContractError", () => {
+  it("passes through XelmaError instances unchanged", () => {
+    const err = new InsufficientBalanceError();
+    expect(wrapContractError(err)).toBe(err);
+  });
+
+  it("maps numeric code 9 to InsufficientBalanceError", () => {
+    const err = wrapContractError({ code: 9, message: "n/a" });
+    expect(err).toBeInstanceOf(InsufficientBalanceError);
+  });
+
+  it("parses code from error message string", () => {
+    const err = wrapContractError(new Error("contract error code 28"));
+    expect(err).toBeInstanceOf(StakeExceedsMaxError);
+  });
+
+  it("passes through unrecognized errors unchanged", () => {
+    const original = new Error("network timeout");
+    expect(wrapContractError(original)).toBe(original);
+  });
+
+  it("passes through ExposureCapExceededError", () => {
+    const err = wrapContractError({ code: 29 });
+    expect(err).toBeInstanceOf(ExposureCapExceededError);
+  });
+});
+
+// ─── Type exports ──────────────────────────────────────────────
+
+describe("type exports", () => {
+  it("MintResult has expected shape", () => {
+    const r: MintResult = { minted: true, balance: 0n };
+    expect(r.minted).toBe(true);
+  });
+
+  it("ClaimResult has expected shape", () => {
+    const r: ClaimResult = { claimed: true, amount: 100n };
+    expect(r.claimed).toBe(true);
+  });
+
+  it("PlaceBetParams has expected shape", () => {
+    const p: PlaceBetParams = {
+      user: "G",
+      amount: 1n,
+      side: { tag: "Down", values: undefined },
+    };
+    expect(p.side.tag).toBe("Down");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #197 

Add high-level TypeScript helpers on top of the generated Soroban bindings for the three most common wallet flows: minting initial tokens, placing a bet with pre-flight validation, and claiming pending winnings.

## Changes

### `bindings/src/helpers.ts` (new)
- **`mintIfNeeded(client, user, opts?)`** — checks vXLM balance and calls `mint_initial` if zero (one-time per user, enforced on-chain)
- **`placeBetChecked(client, params, opts?)`** — runs pre-flight checks (paused → `ContractPausedError`, no active round → `NoActiveRoundError`, low balance → `InsufficientBalanceError`), then places the bet and maps any contract error to a typed exception
- **`claimIfPending(client, user, opts?)`** — queries pending winnings and auto-claims if > 0
- **`wrapContractError(err)`** — utility that extracts Soroban error codes from thrown errors and maps them to typed exceptions
- Typed exception hierarchy: `XelmaError` → `InsufficientBalanceError`, `NoActiveRoundError`, `ContractPausedError`, `AlreadyBetError`, `StakeExceedsMaxError`, `ExposureCapExceededError`

### `bindings/tests/integration.test.ts` (new)
- 19 vitest tests covering happy paths, all pre-flight guard failures, error mapping from raw codes/messages, and options forwarding

### `bindings/README.md`
- Added "High-level helpers" section with copy-paste examples for all three helpers and an error reference table

### `bindings/package.json`
- Added `"./helpers"` export entry point so consumers can `import { mintIfNeeded } from "@xelma/bindings/helpers"`
- Added `test:integration` script

## Verification
- `npx tsc --noEmit` — zero type errors
- `npx vitest run tests/integration.test.ts` — 19/19 passed
- No modifications to `src/index.ts` — zero breaking changes to the generated client
