### PR TITLE
 Economics: add pool composition query for transparency before bet close

### DIFF
--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -10,8 +10,8 @@ use crate::errors::ContractError;
 use crate::types::{
     ArchivedRoundSummary, BetSide, ConfigChangeKind, ConfigChangePayload, DataKey,
     OracleHeartbeatRecord, OraclePayload, PendingConfigChange, PrecisionCommitment,
-    PrecisionPrediction, ProtocolHealthStatus, Round, RoundArchiveStatus, RoundMode, UserOutcomeType,
-    UserPosition, UserRoundOutcome, UserStats,
+    PrecisionPrediction, ProtocolHealthStatus, Round, RoundArchiveStatus, RoundMode,
+    RoundPoolStats, UserOutcomeType, UserPosition, UserRoundOutcome, UserStats,
 };
 
 // ─── Economic control limits ─────────────────────────────────────────────────
@@ -365,6 +365,97 @@ impl VirtualTokenContract {
     /// Returns the currently active round, if any
     pub fn get_active_round(env: Env) -> Option<Round> {
         env.storage().persistent().get(&DataKey::ActiveRound)
+    }
+
+    /// Returns live pool-composition metrics for the currently active round.
+    pub fn get_round_pool_stats(env: Env) -> Option<RoundPoolStats> {
+        let round: Round = env.storage().persistent().get(&DataKey::ActiveRound)?;
+        let participants_key = DataKey::RoundParticipants(round.round_id);
+        let participants: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&participants_key)
+            .unwrap_or(Vec::new(&env));
+
+        let mut stats = RoundPoolStats {
+            round_id: round.round_id,
+            mode: round.mode.clone(),
+            total_up_stake: 0,
+            total_down_stake: 0,
+            up_participant_count: 0,
+            down_participant_count: 0,
+            up_stake_ratio_bps: 0,
+            down_stake_ratio_bps: 0,
+            precision_total_stake: 0,
+            precision_participant_count: 0,
+            precision_prediction_count: 0,
+            precision_commitment_count: 0,
+            precision_revealed_count: 0,
+        };
+
+        match round.mode {
+            RoundMode::UpDown => {
+                stats.total_up_stake = round.pool_up;
+                stats.total_down_stake = round.pool_down;
+
+                let mut idx = 0;
+                while idx < participants.len() {
+                    if let Some(user) = participants.get(idx) {
+                        if let Some(position) = env
+                            .storage()
+                            .persistent()
+                            .get::<_, UserPosition>(&DataKey::Position(round.round_id, user))
+                        {
+                            match position.side {
+                                BetSide::Up => stats.up_participant_count += 1,
+                                BetSide::Down => stats.down_participant_count += 1,
+                            }
+                        }
+                    }
+                    idx += 1;
+                }
+
+                let total_stake = round.pool_up.checked_add(round.pool_down).unwrap_or(0);
+                if total_stake > 0 {
+                    stats.up_stake_ratio_bps = ((round.pool_up as u128)
+                        .saturating_mul(BPS_DENOMINATOR as u128)
+                        / total_stake as u128) as u32;
+                    stats.down_stake_ratio_bps = ((round.pool_down as u128)
+                        .saturating_mul(BPS_DENOMINATOR as u128)
+                        / total_stake as u128) as u32;
+                }
+            }
+            RoundMode::Precision => {
+                stats.precision_participant_count = participants.len();
+
+                let mut idx = 0;
+                while idx < participants.len() {
+                    if let Some(user) = participants.get(idx) {
+                        if let Some(prediction) =
+                            env.storage().persistent().get::<_, PrecisionPrediction>(
+                                &DataKey::PrecisionPosition(round.round_id, user.clone()),
+                            )
+                        {
+                            stats.precision_prediction_count += 1;
+                            stats.precision_total_stake += prediction.amount;
+                        } else if let Some(commitment) =
+                            env.storage().persistent().get::<_, PrecisionCommitment>(
+                                &DataKey::PrecisionCommitment(round.round_id, user),
+                            )
+                        {
+                            stats.precision_commitment_count += 1;
+                            stats.precision_total_stake += commitment.amount;
+                            if commitment.revealed {
+                                stats.precision_revealed_count += 1;
+                            }
+                        }
+                    }
+                    idx += 1;
+                }
+            }
+        }
+
+        Some(stats)
     }
 
     /// Returns the ID of the last created round (0 if no rounds created yet)

--- a/contracts/src/tests/betting.rs
+++ b/contracts/src/tests/betting.rs
@@ -381,3 +381,133 @@ fn test_get_max_stake_returns_configured_value() {
     apply_max_stake(&env, &client, None);
     assert_eq!(client.get_max_stake(), None);
 }
+
+#[test]
+fn test_get_round_pool_stats_no_active_round() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_round_pool_stats(), None);
+}
+
+#[test]
+fn test_get_round_pool_stats_empty_updown_pool() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.create_round(&1_0000000, &None);
+
+    let stats = client.get_round_pool_stats().expect("active round stats");
+    assert_eq!(stats.total_up_stake, 0);
+    assert_eq!(stats.total_down_stake, 0);
+    assert_eq!(stats.up_participant_count, 0);
+    assert_eq!(stats.down_participant_count, 0);
+    assert_eq!(stats.up_stake_ratio_bps, 0);
+    assert_eq!(stats.down_stake_ratio_bps, 0);
+    assert_eq!(stats.precision_total_stake, 0);
+    assert_eq!(stats.precision_participant_count, 0);
+}
+
+#[test]
+fn test_get_round_pool_stats_partial_updown_pool() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+    client.create_round(&1_0000000, &None);
+    client.place_bet(&alice, &100_0000000, &BetSide::Up);
+    client.place_bet(&bob, &200_0000000, &BetSide::Up);
+
+    let stats = client.get_round_pool_stats().expect("active round stats");
+    assert_eq!(stats.total_up_stake, 300_0000000);
+    assert_eq!(stats.total_down_stake, 0);
+    assert_eq!(stats.up_participant_count, 2);
+    assert_eq!(stats.down_participant_count, 0);
+    assert_eq!(stats.up_stake_ratio_bps, 10_000);
+    assert_eq!(stats.down_stake_ratio_bps, 0);
+}
+
+#[test]
+fn test_get_round_pool_stats_full_updown_pool() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+    client.mint_initial(&carol);
+    client.create_round(&1_0000000, &None);
+    client.place_bet(&alice, &100_0000000, &BetSide::Up);
+    client.place_bet(&bob, &200_0000000, &BetSide::Down);
+    client.place_bet(&carol, &300_0000000, &BetSide::Down);
+
+    let stats = client.get_round_pool_stats().expect("active round stats");
+    let round = client.get_active_round().expect("active round");
+    assert_eq!(stats.total_up_stake, round.pool_up);
+    assert_eq!(stats.total_down_stake, round.pool_down);
+    assert_eq!(stats.up_participant_count, 1);
+    assert_eq!(stats.down_participant_count, 2);
+    assert_eq!(stats.up_stake_ratio_bps, 1_666);
+    assert_eq!(stats.down_stake_ratio_bps, 8_333);
+}
+
+#[test]
+fn test_get_round_pool_stats_precision_pool() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+    client.create_round(&1_0000000, &Some(1));
+    client.place_precision_prediction(&alice, &125_0000000, &1_1000000);
+    client.commit_prediction(
+        &bob,
+        &soroban_sdk::BytesN::from_array(&env, &[7; 32]),
+        &75_0000000,
+    );
+
+    let stats = client.get_round_pool_stats().expect("active round stats");
+    assert_eq!(stats.total_up_stake, 0);
+    assert_eq!(stats.total_down_stake, 0);
+    assert_eq!(stats.up_participant_count, 0);
+    assert_eq!(stats.down_participant_count, 0);
+    assert_eq!(stats.up_stake_ratio_bps, 0);
+    assert_eq!(stats.down_stake_ratio_bps, 0);
+    assert_eq!(stats.precision_total_stake, 200_0000000);
+    assert_eq!(stats.precision_participant_count, 2);
+    assert_eq!(stats.precision_prediction_count, 1);
+    assert_eq!(stats.precision_commitment_count, 1);
+    assert_eq!(stats.precision_revealed_count, 0);
+}

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -239,6 +239,30 @@ pub struct Round {
     pub mode: RoundMode,     // Round mode: UpDown (0) or Precision (1)
 }
 
+/// Aggregated active-round pool composition for frontend transparency.
+///
+/// Up/Down rounds populate the up/down pools, counts, and stake ratios.
+/// Precision rounds populate the precision totals and participant counters while
+/// leaving side-specific Up/Down fields at zero. Ratios are basis points of
+/// the mode's total visible stake (10_000 = 100%).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoundPoolStats {
+    pub round_id: u64,
+    pub mode: RoundMode,
+    pub total_up_stake: i128,
+    pub total_down_stake: i128,
+    pub up_participant_count: u32,
+    pub down_participant_count: u32,
+    pub up_stake_ratio_bps: u32,
+    pub down_stake_ratio_bps: u32,
+    pub precision_total_stake: i128,
+    pub precision_participant_count: u32,
+    pub precision_prediction_count: u32,
+    pub precision_commitment_count: u32,
+    pub precision_revealed_count: u32,
+}
+
 /// Terminal outcome recorded when a round leaves the active state.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
## Summary
Description
Added a new contract type RoundPoolStats in contracts/src/types.rs with fields for round id, mode, Up/Down totals and participant counts, stake ratios in basis points, and Precision-mode totals and counters (predictions/commitments/reveals).
Implemented get_round_pool_stats(env: Env) -> Option<RoundPoolStats> in contracts/src/contract.rs which reads DataKey::ActiveRound and DataKey::RoundParticipants, iterates participants to derive per-side participant counts and precision prediction/commitment counts, and computes stake ratios safely using u128 math.
Added unit tests in contracts/src/tests/betting.rs covering no active round, empty Up/Down pool, partial Up/Down pool, full Up/Down pool (verifies ratios), and a Precision-mode scenario (prediction + commitment counters and totals).
Minor formatting and small defensive math adjustments to ensure ratio computation uses u128 and saturating multiplication to avoid overflow.

Testing
Ran cargo check -p xelma-contract --lib, which completed successfully.
Attempted to run cargo test -p xelma-contract test_get_round_pool_stats -- --nocapture, but the test run could not complete because the repository contains pre-existing, unrelated compile-time errors in other test modules (e.g. issues under contracts/src/tests/*) that block executing the new tests in the full test build.
Ran git diff --check / rustfmt checks as part of the iteration and addressed small formatting tweaks (no linter violations remain for the modified files).

- What changed and why?

## Linked issues

- Closes #187 

## Validation

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `cd bindings && npm ci && npm run build`

## Governance checklist

- [ ] I reviewed `CONTRIBUTING.md` for workflow expectations
- [ ] I checked `CODEOWNERS` impact for touched paths
- [ ] I followed `SUPPORT.md` disclosure guidance for any security-sensitive change

## Snapshot policy

- [ ] If snapshot files under `contracts/test_snapshots/` changed, I reviewed the diff and confirmed every change is intentional
- [ ] If snapshot drift was reported in CI, I either regenerated snapshots or marked the drift as expected in the PR description
