### PR TITLE
Add settlement conservation invariants, round templates, and leaderboard seasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,10 @@ async function watchForNewRounds(contractId: string) {
 - `initialize(admin, oracle)` - One-time contract setup
 - `create_round(start_price, mode)` - Start new betting round (mode: 0=Up/Down, 1=Precision)
 - `set_windows(bet_ledgers, run_ledgers)` - Configure round timing windows
+- `set_round_template(start_price, mode)` - Store the blueprint used by `create_next_from_template`
+- `clear_round_template()` - Remove the configured round template
+- `create_next_from_template()` - Create the next round from the stored template (fails if a round is already active or no template is set)
+- `reset_leaderboard_season()` - Archive the active leaderboard season's rankings and advance to the next season
 
 ### Oracle Functions:
 - `resolve_round(payload)` - Resolve round and trigger payouts (requires `OraclePayload` with price, timestamp, and round ID)
@@ -581,6 +585,12 @@ async function watchForNewRounds(contractId: string) {
 - `get_max_precision_participants()` - Check the active Precision participant cap
 - `get_precision_predictions()` - View all predictions in current Precision round
 - `get_updown_positions()` - View all positions in current Up/Down round
+- `get_round_template()` - View the configured round template, if any
+- `get_leaderboard_by_wins(offset, limit)` / `get_leaderboard_by_streak(offset, limit)` - Paginated lifetime (all-time) leaderboards, independent of seasons
+- `get_current_season_id()` - Id of the currently-active leaderboard season (default 1)
+- `get_season_user_stats(season_id, user)` - A user's win/loss/streak stats scoped to one season (active or archived)
+- `get_season_leaderboard_by_wins(season_id, offset, limit)` / `get_season_leaderboard_by_streak(season_id, offset, limit)` - Paginated season-scoped leaderboards; transparently served live for the active season or from the frozen archive for a past one
+- `get_season_archive(season_id)` - The frozen snapshot of a past season's final rankings
 
 ---
 

--- a/contracts/src/betting.rs
+++ b/contracts/src/betting.rs
@@ -7,7 +7,8 @@ use crate::common::{
 use crate::config::get_max_precision_participants;
 use crate::errors::ContractError;
 use crate::types::{
-    BetSide, DataKey, PrecisionCommitment, PrecisionPrediction, Round, RoundMode, UserPosition,
+    BetSide, DataKey, PrecisionCommitment, PrecisionPrediction, Round, RoundMode, RoundTemplate,
+    UserPosition,
 };
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, Vec};
@@ -155,6 +156,53 @@ pub fn create_round(env: Env, start_price: u128, mode: Option<u32>) -> Result<()
     );
 
     Ok(())
+}
+
+/// Creates the next round from the admin-configured template (admin only).
+///
+/// This is the "keeper" entry point for always-on demos: rather than an
+/// operator re-supplying `start_price` / `mode` after every settle or
+/// cancel, a keeper (holding the admin key) calls this once a round has
+/// left the active state. Round creation is delegated to [`create_round`]
+/// itself, so the single-active-round guard (`RoundAlreadyActive`) is
+/// inherited verbatim — overlap is structurally impossible, not just
+/// checked twice in two places that could drift apart.
+pub fn create_next_from_template(env: Env) -> Result<u64, ContractError> {
+    _require_supported_schema(&env)?;
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::AdminNotSet)?;
+    admin.require_auth();
+    _ensure_not_paused(&env).inspect_err(|&e| {
+        _emit_action_rejected(&env, &admin, symbol_short!("nxttmpl"), e);
+    })?;
+
+    let template: RoundTemplate = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RoundTemplate)
+        .ok_or(ContractError::NoRoundTemplate)
+        .inspect_err(|&e| {
+            _emit_action_rejected(&env, &admin, symbol_short!("nxttmpl"), e);
+        })?;
+
+    create_round(env.clone(), template.start_price, template.mode)?;
+
+    let round_id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LastRoundId)
+        .unwrap_or(0);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (symbol_short!("template"), symbol_short!("applied")),
+        (round_id, template.start_price, template.mode.unwrap_or(0)),
+    );
+
+    Ok(round_id)
 }
 
 pub fn place_bet(

--- a/contracts/src/common.rs
+++ b/contracts/src/common.rs
@@ -9,6 +9,10 @@ pub const MAX_MIN_PARTICIPANTS: u32 = 10_000;
 pub const DEFAULT_MAX_PRECISION_PARTICIPANTS: u32 = 1_000;
 pub const MAX_PRECISION_PARTICIPANTS_LIMIT: u32 = 10_000;
 pub const MAX_PAGE_SIZE: u32 = 100;
+/// Maximum entries retained in each bounded leaderboard index (lifetime and
+/// per-season). Keeps insertion-sort maintenance cost bounded on every
+/// win/loss update, at the cost of not tracking ranks below the top N.
+pub const LEADERBOARD_LIMIT: u32 = 100;
 
 // ─── Oracle heartbeat limits ──────────────────────────────────────────────────
 pub const DEFAULT_ORACLE_STALE_THRESHOLD: u64 = 3_600; // 1 hour

--- a/contracts/src/config.rs
+++ b/contracts/src/config.rs
@@ -7,11 +7,13 @@ use crate::common::{
     DEFAULT_ORACLE_STALE_THRESHOLD, DEFAULT_RUN_WINDOW_LEDGERS, MAX_ARCHIVE_RETENTION,
     MAX_BET_WINDOW_LEDGERS, MAX_CLOSE_BUFFER_LEDGERS, MAX_MIN_PARTICIPANTS,
     MAX_ORACLE_DEVIATION_BPS, MAX_ORACLE_STALE_THRESHOLD, MAX_PRECISION_PARTICIPANTS_LIMIT,
-    MAX_PROTOCOL_FEE_BPS, MAX_RUN_WINDOW_LEDGERS, MIN_ARCHIVE_RETENTION, MIN_CAP_VALUE,
-    MIN_ORACLE_STALE_THRESHOLD,
+    MAX_PROTOCOL_FEE_BPS, MAX_RUN_WINDOW_LEDGERS, MAX_START_PRICE, MIN_ARCHIVE_RETENTION,
+    MIN_CAP_VALUE, MIN_ORACLE_STALE_THRESHOLD, MIN_START_PRICE,
 };
 use crate::errors::ContractError;
-use crate::types::{ConfigChangeKind, ConfigChangePayload, DataKey, PendingConfigChange};
+use crate::types::{
+    ConfigChangeKind, ConfigChangePayload, DataKey, PendingConfigChange, RoundTemplate,
+};
 use soroban_sdk::{symbol_short, Address, Env};
 
 pub fn set_windows(env: Env, bet_ledgers: u32, run_ledgers: u32) -> Result<(), ContractError> {
@@ -479,6 +481,104 @@ pub fn get_archive_retention(env: Env) -> u32 {
         .persistent()
         .get(&key)
         .unwrap_or(DEFAULT_ARCHIVE_RETENTION)
+}
+
+// ─── Round templates (create-next keeper) ────────────────────────────────────
+
+/// Stores the admin's blueprint for `create_next_from_template` (admin only).
+///
+/// Validated with the exact same rules `create_round` applies, so a template
+/// can never produce a round that `create_round` itself would reject.
+pub fn set_round_template(
+    env: Env,
+    start_price: u128,
+    mode: Option<u32>,
+) -> Result<(), ContractError> {
+    _require_supported_schema(&env)?;
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::AdminNotSet)?;
+    admin.require_auth();
+    _ensure_not_paused(&env).inspect_err(|&e| {
+        _emit_action_rejected(&env, &admin, symbol_short!("set_tmpl"), e);
+    })?;
+
+    _validate_round_template(start_price, mode).inspect_err(|&e| {
+        _emit_action_rejected(&env, &admin, symbol_short!("set_tmpl"), e);
+    })?;
+
+    let key = DataKey::RoundTemplate;
+    env.storage()
+        .persistent()
+        .set(&key, &RoundTemplate { start_price, mode });
+    _extend_persistent_ttl(&env, &key);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (symbol_short!("template"), symbol_short!("set")),
+        (start_price, mode.unwrap_or(0)),
+    );
+    Ok(())
+}
+
+/// Removes the configured round template (admin only).
+pub fn clear_round_template(env: Env) -> Result<(), ContractError> {
+    _require_supported_schema(&env)?;
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::AdminNotSet)?;
+    admin.require_auth();
+    _ensure_not_paused(&env).inspect_err(|&e| {
+        _emit_action_rejected(&env, &admin, symbol_short!("clr_tmpl"), e);
+    })?;
+
+    let key = DataKey::RoundTemplate;
+    if !env.storage().persistent().has(&key) {
+        _emit_action_rejected(
+            &env,
+            &admin,
+            symbol_short!("clr_tmpl"),
+            ContractError::NoRoundTemplate,
+        );
+        return Err(ContractError::NoRoundTemplate);
+    }
+    env.storage().persistent().remove(&key);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (symbol_short!("template"), symbol_short!("cleared")),
+        (env.ledger().sequence(),),
+    );
+    Ok(())
+}
+
+/// Returns the configured round template, if any.
+pub fn get_round_template(env: Env) -> Option<RoundTemplate> {
+    let key = DataKey::RoundTemplate;
+    _extend_persistent_ttl(&env, &key);
+    env.storage().persistent().get(&key)
+}
+
+/// Same validation `create_round` performs on `(start_price, mode)`, applied
+/// up front at template-set time so a stored template can never later fail
+/// `create_round`'s own checks for a reason unrelated to round overlap.
+pub fn _validate_round_template(
+    start_price: u128,
+    mode: Option<u32>,
+) -> Result<(), ContractError> {
+    if start_price < MIN_START_PRICE || start_price > MAX_START_PRICE {
+        return Err(ContractError::InvalidStartPrice);
+    }
+    if let Some(m) = mode {
+        if m > 1 {
+            return Err(ContractError::InvalidMode);
+        }
+    }
+    Ok(())
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -10,8 +10,8 @@ use crate::types::{
     ArchivedRoundSummary, BetSide, ConfigChangeKind, ConfigChangePayload, DataKey,
     OracleHeartbeatRecord, OraclePayload, OracleRotationProposal, PendingConfigChange,
     PrecisionPrediction, ProtocolHealthStatus, ProtocolStatus, Round, RoundArchiveStatus,
-    RoundPhase, RoundPoolStats, RoundStatus, RuntimeMode, SimulationResult, UserPosition,
-    UserRoundOutcome, UserStats,
+    RoundPhase, RoundPoolStats, RoundStatus, RoundTemplate, RuntimeMode, SimulationResult,
+    UserPosition, UserRoundOutcome, UserStats,
 };
 
 // ─── Economic control limits ─────────────────────────────────────────────────
@@ -615,6 +615,32 @@ impl VirtualTokenContract {
         mode: Option<u32>,
     ) -> Result<(), ContractError> {
         betting::create_round(env, start_price, mode)
+    }
+
+    /// Stores the admin's blueprint for `create_next_from_template` (admin only).
+    pub fn set_round_template(
+        env: Env,
+        start_price: u128,
+        mode: Option<u32>,
+    ) -> Result<(), ContractError> {
+        config::set_round_template(env, start_price, mode)
+    }
+
+    /// Removes the configured round template (admin only).
+    pub fn clear_round_template(env: Env) -> Result<(), ContractError> {
+        config::clear_round_template(env)
+    }
+
+    /// Returns the configured round template, if any.
+    pub fn get_round_template(env: Env) -> Option<RoundTemplate> {
+        config::get_round_template(env)
+    }
+
+    /// Creates the next round from the configured template (admin only).
+    /// Fails with `RoundAlreadyActive` if a round is already active and
+    /// with `NoRoundTemplate` if no template has been configured.
+    pub fn create_next_from_template(env: Env) -> Result<u64, ContractError> {
+        betting::create_next_from_template(env)
     }
 
     pub fn place_bet(

--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -8,10 +8,11 @@ use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Ma
 use crate::errors::ContractError;
 use crate::types::{
     ArchivedRoundSummary, BetSide, ConfigChangeKind, ConfigChangePayload, DataKey,
-    OracleHeartbeatRecord, OraclePayload, OracleRotationProposal, PendingConfigChange,
-    PrecisionPrediction, ProtocolHealthStatus, ProtocolStatus, Round, RoundArchiveStatus,
-    RoundPhase, RoundPoolStats, RoundStatus, RoundTemplate, RuntimeMode, SimulationResult,
-    UserPosition, UserRoundOutcome, UserStats,
+    LeaderboardEntry, OracleHeartbeatRecord, OraclePayload, OracleRotationProposal,
+    PendingConfigChange, PrecisionPrediction, ProtocolHealthStatus, ProtocolStatus, Round,
+    RoundArchiveStatus, RoundPhase, RoundPoolStats, RoundStatus, RoundTemplate, RuntimeMode,
+    SeasonArchive, SeasonLeaderboardEntry, SimulationResult, UserPosition, UserRoundOutcome,
+    UserStats,
 };
 
 // ─── Economic control limits ─────────────────────────────────────────────────
@@ -85,6 +86,7 @@ use crate::admin;
 use crate::betting;
 use crate::common;
 use crate::config;
+use crate::leaderboard;
 use crate::queries;
 use crate::settlement;
 
@@ -790,6 +792,61 @@ impl VirtualTokenContract {
     /// Does not mutate storage. Returns SimulationResult.
     pub fn simulate_payout(env: Env, final_price: u128) -> Result<SimulationResult, ContractError> {
         queries::simulate_payout(env, final_price)
+    }
+
+    // ─── Leaderboards (lifetime + seasons) ──────────────────────────────────
+
+    /// Paginated lifetime wins leaderboard (all-time, independent of seasons).
+    pub fn get_leaderboard_by_wins(env: Env, offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
+        leaderboard::get_leaderboard_by_wins(env, offset, limit)
+    }
+
+    /// Paginated lifetime best-streak leaderboard (all-time, independent of seasons).
+    pub fn get_leaderboard_by_streak(env: Env, offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
+        leaderboard::get_leaderboard_by_streak(env, offset, limit)
+    }
+
+    /// Returns the id of the currently-active leaderboard season (default 1).
+    pub fn get_current_season_id(env: Env) -> u32 {
+        leaderboard::get_current_season_id(env)
+    }
+
+    /// Returns a user's season-scoped stats for `season_id` (active or archived).
+    pub fn get_season_user_stats(env: Env, season_id: u32, user: Address) -> UserStats {
+        leaderboard::get_season_user_stats(env, season_id, user)
+    }
+
+    /// Freezes the active season's rankings into a permanent archive and
+    /// advances to the next season (admin only). Returns the new season id.
+    pub fn reset_leaderboard_season(env: Env) -> Result<u32, ContractError> {
+        leaderboard::reset_leaderboard_season(env)
+    }
+
+    /// Returns the frozen archive for a past season, if it has been reset.
+    pub fn get_season_archive(env: Env, season_id: u32) -> Option<SeasonArchive> {
+        leaderboard::get_season_archive(env, season_id)
+    }
+
+    /// Paginated wins leaderboard for `season_id` — live for the active
+    /// season, frozen archive for any past season.
+    pub fn get_season_leaderboard_by_wins(
+        env: Env,
+        season_id: u32,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<SeasonLeaderboardEntry> {
+        leaderboard::get_season_leaderboard_by_wins(env, season_id, offset, limit)
+    }
+
+    /// Paginated best-streak leaderboard for `season_id` — live for the
+    /// active season, frozen archive for any past season.
+    pub fn get_season_leaderboard_by_streak(
+        env: Env,
+        season_id: u32,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<SeasonLeaderboardEntry> {
+        leaderboard::get_season_leaderboard_by_streak(env, season_id, offset, limit)
     }
 }
 

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -100,4 +100,6 @@ pub enum ContractError {
     InvalidCommitment = 63,
     /// Reveal salt fails minimum entropy rules (all-zero or constant-byte)
     InvalidSalt = 64,
+    /// `create_next_from_template` called with no round template configured
+    NoRoundTemplate = 65,
 }

--- a/contracts/src/leaderboard.rs
+++ b/contracts/src/leaderboard.rs
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: MIT
+//! Leaderboard storage and queries: an all-time (lifetime) leaderboard plus
+//! seasonal leaderboards that can be reset without losing history.
+//!
+//! ## Lifetime leaderboard
+//! Two bounded (top [`LEADERBOARD_LIMIT`]) indexes — `LeaderboardWins` and
+//! `LeaderboardStreak` — are maintained incrementally on every win/loss via
+//! [`_update_leaderboards`], ranked by the same lifetime `UserStats` totals
+//! `get_user_stats` already exposes. This scope is untouched by seasons.
+//!
+//! ## Seasons
+//! A season is a scope-limited leaderboard layered on top of the lifetime
+//! one: `SeasonId` names the *active* season (default 1), and
+//! `SeasonUserStats(season_id, user)` tracks win/loss/streak counters scoped
+//! to that season only — independent of, and never mutating, the lifetime
+//! totals above ("hack campaigns need seasons without wiping history").
+//!
+//! [`reset_leaderboard_season`] (admin only) freezes the active season's
+//! bounded rankings into a permanent `SeasonArchive(season_id)` snapshot,
+//! then advances `SeasonId`. Nothing is deleted: `SeasonUserStats` entries
+//! for old seasons stay addressable forever via [`get_season_user_stats`],
+//! and [`get_season_leaderboard_by_wins`] / [`get_season_leaderboard_by_streak`]
+//! transparently serve the live index for the current season or the frozen
+//! archive for any past one — callers never need to know which.
+
+use crate::admin::{_ensure_not_paused, _require_supported_schema};
+use crate::common::{
+    _emit_action_rejected, _extend_persistent_ttl, LEADERBOARD_LIMIT, MAX_PAGE_SIZE,
+};
+use crate::errors::ContractError;
+use crate::types::{DataKey, LeaderboardEntry, SeasonArchive, SeasonLeaderboardEntry, UserStats};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
+
+fn lifetime_user_stats(env: &Env, user: &Address) -> UserStats {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserStats(user.clone()))
+        .unwrap_or(UserStats {
+            total_wins: 0,
+            total_losses: 0,
+            current_streak: 0,
+            best_streak: 0,
+        })
+}
+
+fn season_user_stats_raw(env: &Env, season_id: u32, user: &Address) -> UserStats {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SeasonUserStats(season_id, user.clone()))
+        .unwrap_or(UserStats {
+            total_wins: 0,
+            total_losses: 0,
+            current_streak: 0,
+            best_streak: 0,
+        })
+}
+
+// ─── Bounded-index maintenance ────────────────────────────────────────────────
+//
+// Every bounded index (lifetime wins/streak, active-season wins/streak) is
+// maintained the same way: drop the user if already present, re-insert in
+// sorted order (metric descending, address ascending as a deterministic
+// tie-breaker), then truncate to LEADERBOARD_LIMIT. Cost is O(n) per update,
+// bounded by LEADERBOARD_LIMIT — acceptable for a top-N ranking structure.
+
+fn reinsert_sorted_by_wins(
+    env: &Env,
+    addresses: Vec<Address>,
+    stats_of: impl Fn(&Address) -> UserStats,
+) -> Vec<Address> {
+    let mut sorted: Vec<Address> = Vec::new(env);
+    for addr in addresses.iter() {
+        let addr_stats = stats_of(&addr);
+        let mut inserted = false;
+        for i in 0..sorted.len() {
+            let other = sorted.get_unchecked(i);
+            let other_stats = stats_of(&other);
+            if addr_stats.total_wins > other_stats.total_wins
+                || (addr_stats.total_wins == other_stats.total_wins && addr < other)
+            {
+                sorted.insert(i, addr.clone());
+                inserted = true;
+                break;
+            }
+        }
+        if !inserted {
+            sorted.push_back(addr);
+        }
+    }
+    sorted
+}
+
+fn reinsert_sorted_by_streak(
+    env: &Env,
+    addresses: Vec<Address>,
+    stats_of: impl Fn(&Address) -> UserStats,
+) -> Vec<Address> {
+    let mut sorted: Vec<Address> = Vec::new(env);
+    for addr in addresses.iter() {
+        let addr_stats = stats_of(&addr);
+        let mut inserted = false;
+        for i in 0..sorted.len() {
+            let other = sorted.get_unchecked(i);
+            let other_stats = stats_of(&other);
+            if addr_stats.best_streak > other_stats.best_streak
+                || (addr_stats.best_streak == other_stats.best_streak && addr < other)
+            {
+                sorted.insert(i, addr.clone());
+                inserted = true;
+                break;
+            }
+        }
+        if !inserted {
+            sorted.push_back(addr);
+        }
+    }
+    sorted
+}
+
+fn upsert_bounded_index(env: &Env, key: &DataKey, sorted: Vec<Address>) {
+    let limit = LEADERBOARD_LIMIT.min(sorted.len());
+    let mut bounded = Vec::new(env);
+    for i in 0..limit {
+        bounded.push_back(sorted.get_unchecked(i));
+    }
+    env.storage().persistent().set(key, &bounded);
+    _extend_persistent_ttl(env, key);
+}
+
+fn without_user(env: &Env, list: &Vec<Address>, user: &Address) -> Vec<Address> {
+    let mut filtered = Vec::new(env);
+    for addr in list.iter() {
+        if addr != *user {
+            filtered.push_back(addr);
+        }
+    }
+    filtered
+}
+
+// ─── Lifetime leaderboard ─────────────────────────────────────────────────────
+
+/// Re-ranks `user` into both lifetime bounded indexes after a win/loss.
+/// Called from `settlement::_update_stats_win` / `_update_stats_loss`,
+/// **after** the lifetime `UserStats` write, so the freshly-updated totals
+/// are what gets ranked.
+pub fn _update_leaderboards(env: &Env, user: Address) {
+    let wins_key = DataKey::LeaderboardWins;
+    let wins_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&wins_key)
+        .unwrap_or(Vec::new(env));
+    let mut candidates = without_user(env, &wins_list, &user);
+    candidates.push_back(user.clone());
+    let sorted = reinsert_sorted_by_wins(env, candidates, |addr| lifetime_user_stats(env, addr));
+    upsert_bounded_index(env, &wins_key, sorted);
+
+    let streak_key = DataKey::LeaderboardStreak;
+    let streak_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&streak_key)
+        .unwrap_or(Vec::new(env));
+    let mut candidates = without_user(env, &streak_list, &user);
+    candidates.push_back(user);
+    let sorted = reinsert_sorted_by_streak(env, candidates, |addr| lifetime_user_stats(env, addr));
+    upsert_bounded_index(env, &streak_key, sorted);
+}
+
+/// Returns a paginated slice of the lifetime wins leaderboard, ordered by
+/// total wins descending (address ascending as a tie-breaker).
+pub fn get_leaderboard_by_wins(env: Env, offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
+    let limit = limit.min(MAX_PAGE_SIZE);
+    if limit == 0 {
+        return Vec::new(&env);
+    }
+    let key = DataKey::LeaderboardWins;
+    _extend_persistent_ttl(&env, &key);
+    let list: Vec<Address> = env.storage().persistent().get(&key).unwrap_or(Vec::new(&env));
+
+    let total = list.len();
+    if offset >= total {
+        return Vec::new(&env);
+    }
+    let end = offset.saturating_add(limit).min(total);
+
+    let mut result = Vec::new(&env);
+    for i in offset..end {
+        if let Some(user) = list.get(i) {
+            let stats = lifetime_user_stats(&env, &user);
+            result.push_back(LeaderboardEntry { user, stats });
+        }
+    }
+    result
+}
+
+/// Returns a paginated slice of the lifetime best-streak leaderboard,
+/// ordered by best streak descending (address ascending as a tie-breaker).
+pub fn get_leaderboard_by_streak(env: Env, offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
+    let limit = limit.min(MAX_PAGE_SIZE);
+    if limit == 0 {
+        return Vec::new(&env);
+    }
+    let key = DataKey::LeaderboardStreak;
+    _extend_persistent_ttl(&env, &key);
+    let list: Vec<Address> = env.storage().persistent().get(&key).unwrap_or(Vec::new(&env));
+
+    let total = list.len();
+    if offset >= total {
+        return Vec::new(&env);
+    }
+    let end = offset.saturating_add(limit).min(total);
+
+    let mut result = Vec::new(&env);
+    for i in offset..end {
+        if let Some(user) = list.get(i) {
+            let stats = lifetime_user_stats(&env, &user);
+            result.push_back(LeaderboardEntry { user, stats });
+        }
+    }
+    result
+}
+
+// ─── Seasons ───────────────────────────────────────────────────────────────
+
+pub fn _current_season_id(env: &Env) -> u32 {
+    env.storage().persistent().get(&DataKey::SeasonId).unwrap_or(1)
+}
+
+/// Returns the id of the currently-active leaderboard season (default 1).
+pub fn get_current_season_id(env: Env) -> u32 {
+    let key = DataKey::SeasonId;
+    _extend_persistent_ttl(&env, &key);
+    _current_season_id(&env)
+}
+
+/// Returns `user`'s season-scoped stats for `season_id` — works uniformly
+/// for the active season or any past (archived) one, since per-season stats
+/// are never deleted.
+pub fn get_season_user_stats(env: Env, season_id: u32, user: Address) -> UserStats {
+    let key = DataKey::SeasonUserStats(season_id, user);
+    _extend_persistent_ttl(&env, &key);
+    env.storage().persistent().get(&key).unwrap_or(UserStats {
+        total_wins: 0,
+        total_losses: 0,
+        current_streak: 0,
+        best_streak: 0,
+    })
+}
+
+fn _update_season_leaderboards(env: &Env, season_id: u32, user: Address) {
+    let wins_key = DataKey::SeasonLeaderboardWins;
+    let wins_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&wins_key)
+        .unwrap_or(Vec::new(env));
+    let mut candidates = without_user(env, &wins_list, &user);
+    candidates.push_back(user.clone());
+    let sorted = reinsert_sorted_by_wins(env, candidates, |addr| {
+        season_user_stats_raw(env, season_id, addr)
+    });
+    upsert_bounded_index(env, &wins_key, sorted);
+
+    let streak_key = DataKey::SeasonLeaderboardStreak;
+    let streak_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&streak_key)
+        .unwrap_or(Vec::new(env));
+    let mut candidates = without_user(env, &streak_list, &user);
+    candidates.push_back(user);
+    let sorted = reinsert_sorted_by_streak(env, candidates, |addr| {
+        season_user_stats_raw(env, season_id, addr)
+    });
+    upsert_bounded_index(env, &streak_key, sorted);
+}
+
+/// Records a season-scoped win for `user` in the active season. Mirrors
+/// `settlement::_update_stats_win` but scoped to `SeasonUserStats`, entirely
+/// independent of the lifetime totals.
+pub fn _update_season_stats_win(env: &Env, user: Address) -> Result<(), ContractError> {
+    let season_id = _current_season_id(env);
+    let key = DataKey::SeasonUserStats(season_id, user.clone());
+    let mut stats: UserStats = env.storage().persistent().get(&key).unwrap_or(UserStats {
+        total_wins: 0,
+        total_losses: 0,
+        current_streak: 0,
+        best_streak: 0,
+    });
+
+    stats.total_wins = stats
+        .total_wins
+        .checked_add(1)
+        .ok_or(ContractError::Overflow)?;
+    stats.current_streak = stats
+        .current_streak
+        .checked_add(1)
+        .ok_or(ContractError::Overflow)?;
+    if stats.current_streak > stats.best_streak {
+        stats.best_streak = stats.current_streak;
+    }
+
+    env.storage().persistent().set(&key, &stats);
+    _extend_persistent_ttl(env, &key);
+    _update_season_leaderboards(env, season_id, user);
+    Ok(())
+}
+
+/// Records a season-scoped loss for `user` in the active season.
+pub fn _update_season_stats_loss(env: &Env, user: Address) -> Result<(), ContractError> {
+    let season_id = _current_season_id(env);
+    let key = DataKey::SeasonUserStats(season_id, user.clone());
+    let mut stats: UserStats = env.storage().persistent().get(&key).unwrap_or(UserStats {
+        total_wins: 0,
+        total_losses: 0,
+        current_streak: 0,
+        best_streak: 0,
+    });
+
+    stats.total_losses = stats
+        .total_losses
+        .checked_add(1)
+        .ok_or(ContractError::Overflow)?;
+    stats.current_streak = 0;
+
+    env.storage().persistent().set(&key, &stats);
+    _extend_persistent_ttl(env, &key);
+    _update_season_leaderboards(env, season_id, user);
+    Ok(())
+}
+
+/// Freezes the active season's bounded rankings into a permanent archive
+/// and advances to the next season (admin only).
+///
+/// This is the "archive on reset": nothing is deleted. `SeasonUserStats`
+/// entries for the ending season remain queryable forever via
+/// [`get_season_user_stats`], and the frozen top-N snapshot written here is
+/// what [`get_season_leaderboard_by_wins`] / [`get_season_leaderboard_by_streak`]
+/// serve once the season is no longer active. Only the *active*-season
+/// bounded indexes are cleared, so the new season starts with an empty
+/// ranking rather than inheriting stale entries.
+pub fn reset_leaderboard_season(env: Env) -> Result<u32, ContractError> {
+    _require_supported_schema(&env)?;
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::AdminNotSet)?;
+    admin.require_auth();
+    _ensure_not_paused(&env).inspect_err(|&e| {
+        _emit_action_rejected(&env, &admin, symbol_short!("rst_seas"), e);
+    })?;
+
+    let season_id = _current_season_id(&env);
+
+    let wins_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SeasonLeaderboardWins)
+        .unwrap_or(Vec::new(&env));
+    let streak_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SeasonLeaderboardStreak)
+        .unwrap_or(Vec::new(&env));
+
+    let mut wins_entries: Vec<SeasonLeaderboardEntry> = Vec::new(&env);
+    for addr in wins_list.iter() {
+        let stats = season_user_stats_raw(&env, season_id, &addr);
+        wins_entries.push_back(SeasonLeaderboardEntry {
+            user: addr,
+            wins: stats.total_wins,
+            best_streak: stats.best_streak,
+        });
+    }
+
+    let mut streak_entries: Vec<SeasonLeaderboardEntry> = Vec::new(&env);
+    for addr in streak_list.iter() {
+        let stats = season_user_stats_raw(&env, season_id, &addr);
+        streak_entries.push_back(SeasonLeaderboardEntry {
+            user: addr,
+            wins: stats.total_wins,
+            best_streak: stats.best_streak,
+        });
+    }
+
+    // Distinct participants across both bounded indexes (a user may appear
+    // in both). Bounded by 2*LEADERBOARD_LIMIT, so the O(n^2) dedupe is cheap.
+    let mut distinct_participants: Vec<Address> = Vec::new(&env);
+    for addr in wins_list.iter() {
+        distinct_participants.push_back(addr);
+    }
+    for addr in streak_list.iter() {
+        let mut seen = false;
+        for existing in distinct_participants.iter() {
+            if existing == addr {
+                seen = true;
+                break;
+            }
+        }
+        if !seen {
+            distinct_participants.push_back(addr);
+        }
+    }
+    let participant_count = distinct_participants.len();
+    let ended_at_ledger = env.ledger().sequence();
+
+    let archive = SeasonArchive {
+        season_id,
+        ended_at_ledger,
+        wins: wins_entries,
+        streak: streak_entries,
+        participant_count,
+    };
+    let archive_key = DataKey::SeasonArchive(season_id);
+    env.storage().persistent().set(&archive_key, &archive);
+    _extend_persistent_ttl(&env, &archive_key);
+
+    let new_season_id = season_id.checked_add(1).ok_or(ContractError::Overflow)?;
+    let season_key = DataKey::SeasonId;
+    env.storage().persistent().set(&season_key, &new_season_id);
+    _extend_persistent_ttl(&env, &season_key);
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::SeasonLeaderboardWins);
+    env.storage()
+        .persistent()
+        .remove(&DataKey::SeasonLeaderboardStreak);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (symbol_short!("season"), symbol_short!("reset")),
+        (season_id, new_season_id, ended_at_ledger, participant_count),
+    );
+
+    Ok(new_season_id)
+}
+
+/// Returns the frozen archive for a past season, if one exists (i.e. the
+/// season has been reset at least once since).
+pub fn get_season_archive(env: Env, season_id: u32) -> Option<SeasonArchive> {
+    let key = DataKey::SeasonArchive(season_id);
+    _extend_persistent_ttl(&env, &key);
+    env.storage().persistent().get(&key)
+}
+
+/// Returns a paginated slice of `season_id`'s wins leaderboard. Transparently
+/// serves the live bounded index if `season_id` is the active season, or the
+/// frozen archive snapshot otherwise. Unknown/future season ids return an
+/// empty page rather than erroring, matching the other paginated queries.
+pub fn get_season_leaderboard_by_wins(
+    env: Env,
+    season_id: u32,
+    offset: u32,
+    limit: u32,
+) -> Vec<SeasonLeaderboardEntry> {
+    let limit = limit.min(MAX_PAGE_SIZE);
+    if limit == 0 {
+        return Vec::new(&env);
+    }
+
+    if season_id == _current_season_id(&env) {
+        let key = DataKey::SeasonLeaderboardWins;
+        _extend_persistent_ttl(&env, &key);
+        let list: Vec<Address> = env.storage().persistent().get(&key).unwrap_or(Vec::new(&env));
+        let total = list.len();
+        if offset >= total {
+            return Vec::new(&env);
+        }
+        let end = offset.saturating_add(limit).min(total);
+        let mut result = Vec::new(&env);
+        for i in offset..end {
+            if let Some(user) = list.get(i) {
+                let stats = season_user_stats_raw(&env, season_id, &user);
+                result.push_back(SeasonLeaderboardEntry {
+                    user,
+                    wins: stats.total_wins,
+                    best_streak: stats.best_streak,
+                });
+            }
+        }
+        return result;
+    }
+
+    match get_season_archive(env.clone(), season_id) {
+        None => Vec::new(&env),
+        Some(archive) => page_entries(&env, &archive.wins, offset, limit),
+    }
+}
+
+/// Returns a paginated slice of `season_id`'s best-streak leaderboard. Same
+/// live-vs-archive semantics as [`get_season_leaderboard_by_wins`].
+pub fn get_season_leaderboard_by_streak(
+    env: Env,
+    season_id: u32,
+    offset: u32,
+    limit: u32,
+) -> Vec<SeasonLeaderboardEntry> {
+    let limit = limit.min(MAX_PAGE_SIZE);
+    if limit == 0 {
+        return Vec::new(&env);
+    }
+
+    if season_id == _current_season_id(&env) {
+        let key = DataKey::SeasonLeaderboardStreak;
+        _extend_persistent_ttl(&env, &key);
+        let list: Vec<Address> = env.storage().persistent().get(&key).unwrap_or(Vec::new(&env));
+        let total = list.len();
+        if offset >= total {
+            return Vec::new(&env);
+        }
+        let end = offset.saturating_add(limit).min(total);
+        let mut result = Vec::new(&env);
+        for i in offset..end {
+            if let Some(user) = list.get(i) {
+                let stats = season_user_stats_raw(&env, season_id, &user);
+                result.push_back(SeasonLeaderboardEntry {
+                    user,
+                    wins: stats.total_wins,
+                    best_streak: stats.best_streak,
+                });
+            }
+        }
+        return result;
+    }
+
+    match get_season_archive(env.clone(), season_id) {
+        None => Vec::new(&env),
+        Some(archive) => page_entries(&env, &archive.streak, offset, limit),
+    }
+}
+
+fn page_entries(
+    env: &Env,
+    entries: &Vec<SeasonLeaderboardEntry>,
+    offset: u32,
+    limit: u32,
+) -> Vec<SeasonLeaderboardEntry> {
+    let total = entries.len();
+    if offset >= total {
+        return Vec::new(env);
+    }
+    let end = offset.saturating_add(limit).min(total);
+    let mut result = Vec::new(env);
+    for i in offset..end {
+        if let Some(entry) = entries.get(i) {
+            result.push_back(entry);
+        }
+    }
+    result
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -33,5 +33,5 @@ pub use errors::ContractError;
 pub use types::{
     ArchivedRoundSummary, BetSide, ConfigChangeKind, ConfigChangePayload, DataKey,
     OracleRotationProposal, PendingConfigChange, PrecisionCommitment, PrecisionPrediction,
-    ProtocolHealthStatus, Round, RoundArchiveStatus, UserPosition, UserStats,
+    ProtocolHealthStatus, Round, RoundArchiveStatus, RoundTemplate, UserPosition, UserStats,
 };

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -21,6 +21,7 @@ pub mod common;
 mod config;
 mod contract;
 mod errors;
+mod leaderboard;
 mod queries;
 mod settlement;
 mod types;
@@ -32,6 +33,7 @@ pub use contract::VirtualTokenContract;
 pub use errors::ContractError;
 pub use types::{
     ArchivedRoundSummary, BetSide, ConfigChangeKind, ConfigChangePayload, DataKey,
-    OracleRotationProposal, PendingConfigChange, PrecisionCommitment, PrecisionPrediction,
-    ProtocolHealthStatus, Round, RoundArchiveStatus, RoundTemplate, UserPosition, UserStats,
+    LeaderboardEntry, OracleRotationProposal, PendingConfigChange, PrecisionCommitment,
+    PrecisionPrediction, ProtocolHealthStatus, Round, RoundArchiveStatus, RoundTemplate,
+    SeasonArchive, SeasonLeaderboardEntry, UserPosition, UserStats,
 };

--- a/contracts/src/settlement.rs
+++ b/contracts/src/settlement.rs
@@ -1382,7 +1382,7 @@ pub fn _refund_under_threshold(
 }
 
 pub fn _update_stats_win(env: &Env, user: Address) -> Result<(), ContractError> {
-    let key = DataKey::UserStats(user);
+    let key = DataKey::UserStats(user.clone());
     let mut stats: UserStats = env.storage().persistent().get(&key).unwrap_or(UserStats {
         total_wins: 0,
         total_losses: 0,
@@ -1405,11 +1405,13 @@ pub fn _update_stats_win(env: &Env, user: Address) -> Result<(), ContractError> 
 
     env.storage().persistent().set(&key, &stats);
     _extend_persistent_ttl(env, &key);
+    crate::leaderboard::_update_leaderboards(env, user.clone());
+    crate::leaderboard::_update_season_stats_win(env, user)?;
     Ok(())
 }
 
 pub fn _update_stats_loss(env: &Env, user: Address) -> Result<(), ContractError> {
-    let key = DataKey::UserStats(user);
+    let key = DataKey::UserStats(user.clone());
     let mut stats: UserStats = env.storage().persistent().get(&key).unwrap_or(UserStats {
         total_wins: 0,
         total_losses: 0,
@@ -1425,5 +1427,7 @@ pub fn _update_stats_loss(env: &Env, user: Address) -> Result<(), ContractError>
 
     env.storage().persistent().set(&key, &stats);
     _extend_persistent_ttl(env, &key);
+    crate::leaderboard::_update_leaderboards(env, user.clone());
+    crate::leaderboard::_update_season_stats_loss(env, user)?;
     Ok(())
 }

--- a/contracts/src/settlement.rs
+++ b/contracts/src/settlement.rs
@@ -845,6 +845,31 @@ pub fn _resolve_precision_mode(
                 }
             }
         }
+    } else if total_pot > 0 {
+        // Nobody revealed a prediction (all-commitment round). There is no
+        // closest-guess winner to forfeit the pot to, so — unlike the
+        // mixed-reveal case — every participant's stake must be refunded in
+        // full rather than silently vanishing from circulation (conservation:
+        // sum_refunds == total_pot, fee == 0, no stats mutation).
+        for i in 0..participants.len() {
+            if let Some(user) = participants.get(i) {
+                let stake = participant_amounts.get(i).unwrap_or(0);
+                if stake > 0 {
+                    _accumulate_pending(env, user.clone(), stake)?;
+                    _persist_user_outcome(
+                        env,
+                        round_id,
+                        1,
+                        &user,
+                        2,
+                        0,
+                        stake,
+                        stake,
+                        UserOutcomeType::Refund,
+                    );
+                }
+            }
+        }
     }
 
     Ok(fee_amount)

--- a/contracts/src/tests/conservation.rs
+++ b/contracts/src/tests/conservation.rs
@@ -1,0 +1,686 @@
+// SPDX-License-Identifier: MIT
+//! Stroop-level conservation invariant matrix for settlement.
+//!
+//! **Why**: value leaks hide in interactions between features (fee on/off,
+//! remainder handling, cancellation, and the min-participants fallback —
+//! collectively the closest thing this protocol has to a "dispute"
+//! resolution path, since there is no separate on-chain dispute primitive).
+//! A change that is safe in isolation can silently drop or fabricate a
+//! stroop once combined with another code path. This module pins down the
+//! exact accounting identity for every settlement path so any leak — even a
+//! single stroop — fails a test immediately.
+//!
+//! The core identity checked throughout, per round:
+//! ```text
+//! sum(participant payouts/refunds) + protocol_fee_treasury_delta == total_pot
+//! ```
+//! For Precision mode this holds **exactly** (the contract assigns the
+//! integer-division remainder to a single winner). For UpDown mode with
+//! multiple winners sharing a side, per-winner floor division can drop up to
+//! `winner_count - 1` stroops — that slack is bounded and asserted exactly
+//! (never approximately) in every test below.
+//!
+//! ## Feature matrix
+//!
+//! | # | Mode      | Path                          | Fee | Remainder | Test |
+//! |---|-----------|-------------------------------|-----|-----------|------|
+//! | 1 | UpDown    | Win (2-way split)              | off | yes (1 stroop) | [`updown_win_two_way_split_fee_disabled_pins_exact_truncation`] |
+//! | 2 | UpDown    | Win (2-way split, clean divide) | on  | no        | [`updown_win_two_way_split_fee_enabled_exact_conservation`] |
+//! | 3 | UpDown    | Tie / refund                   | on (must not apply) | n/a | [`updown_tie_refund_ignores_configured_fee`] |
+//! | 4 | UpDown    | One-sided pool / refund         | on (must not apply) | n/a | [`updown_one_sided_pool_ignores_configured_fee`] |
+//! | 5 | UpDown    | Cancel                          | on (must not apply) | n/a | [`updown_cancel_ignores_configured_fee`] |
+//! | 6 | UpDown    | Fallback refund (min-participants) | on (must not apply) | n/a | [`updown_fallback_refund_ignores_configured_fee`] |
+//! | 7 | Precision | Win (single winner)             | off | no        | [`precision_single_winner_fee_disabled_exact_conservation`] |
+//! | 8 | Precision | Win (tie, 2 winners)             | on  | yes (1 stroop, assigned) | [`precision_tie_two_winners_fee_enabled_exact_remainder`] |
+//! | 9 | Precision | All-unrevealed refund           | on (must not apply) | n/a | [`precision_all_unrevealed_refunds_ignores_configured_fee`] |
+//! |10 | Precision | Mixed reveal (forfeit-to-pot)    | on  | no        | [`precision_mixed_reveal_forfeit_fee_enabled_exact_conservation`] |
+//! |11 | Precision | Cancel (mixed reveal/commit)     | on (must not apply) | n/a | [`precision_cancel_mixed_reveal_ignores_configured_fee`] |
+//! |12 | Precision | Fallback refund (mixed reveal/commit) | on (must not apply) | n/a | [`precision_fallback_refund_mixed_reveal_ignores_configured_fee`] |
+//!
+//! Rows 9–10 guard a real regression: `_resolve_precision_mode` used to drop
+//! every committed-but-unrevealed stroop on the floor when **nobody**
+//! revealed (no winner to forfeit the pot to, and no refund branch existed).
+//! That is fixed in `settlement.rs` alongside this suite — row 9 is the
+//! exact scenario that leaked before the fix.
+//!
+//! Two property-based blocks at the bottom add small-random coverage on top
+//! of the fixed matrix above (fixed + small random, per the task spec).
+//!
+//! This file is registered as `mod conservation;` in `tests/mod.rs`, so it
+//! runs under the existing `cargo test --workspace` CI job — no separate
+//! wiring is required for CI inclusion.
+
+use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};
+use crate::types::{BetSide, DataKey, OraclePayload, RoundArchiveStatus};
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    xdr::ToXdr,
+    Address, Bytes, BytesN, Env,
+};
+
+// ─── Shared test helpers ─────────────────────────────────────────────────────
+
+fn setup_contract(env: &Env) -> (VirtualTokenContractClient<'_>, Address, Address, Address) {
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    (client, contract_id, admin, oracle)
+}
+
+/// Writes the protocol fee bps directly into storage, bypassing the
+/// timelocked scheduler (`set_protocol_fee_bps` only *schedules* a pending
+/// change) so tests can exercise a fee-active round immediately. Mirrors the
+/// existing convention in `tests/property_invariants.rs`.
+fn set_fee_bps_now(env: &Env, contract_id: &Address, bps: u32) {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProtocolFeeBps, &bps);
+    });
+}
+
+/// Resolves the currently-active round at `final_price` using a fresh nonce.
+fn resolve_at(
+    env: &Env,
+    client: &VirtualTokenContractClient,
+    contract_id: &Address,
+    final_price: u128,
+) {
+    let round = client
+        .get_active_round()
+        .expect("active round required to resolve");
+    client.resolve_round(&OraclePayload {
+        price: final_price,
+        timestamp: env.ledger().timestamp(),
+        round_id: round.start_ledger,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+}
+
+/// `sha256(price.to_xdr() || salt.to_xdr())` — matches `reveal_prediction`.
+fn make_commitment(env: &Env, price: u128, salt: &BytesN<32>) -> BytesN<32> {
+    let mut preimage = Bytes::new(env);
+    preimage.append(&price.to_xdr(env));
+    preimage.append(&salt.clone().to_xdr(env));
+    let hash = env.crypto().sha256(&preimage);
+    hash.into()
+}
+
+/// Salt satisfying on-chain minimum entropy (non-zero, non-constant bytes).
+fn test_salt(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    let mut i = 0;
+    while i < 32 {
+        bytes[i] = seed.wrapping_add(i as u8).wrapping_mul(17).wrapping_add(3);
+        i += 1;
+    }
+    bytes[0] = seed | 0x80;
+    bytes[31] = seed ^ 0x5A;
+    BytesN::from_array(env, &bytes)
+}
+
+// ─── Row 1–2: UpDown wins ────────────────────────────────────────────────────
+
+/// Row 1 — fee disabled, two winners on the same side sharing an uneven
+/// split. Floor division on each winner independently drops exactly one
+/// stroop here; the assertion pins that exact number so a regression that
+/// drops (or fabricates) an *additional* stroop fails immediately.
+#[test]
+fn updown_win_two_way_split_fee_disabled_pins_exact_truncation() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let charlie = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+    client.mint_initial(&charlie);
+
+    client.create_round(&1_000u128, &None);
+    client.place_bet(&alice, &3, &BetSide::Up);
+    client.place_bet(&bob, &4, &BetSide::Up);
+    client.place_bet(&charlie, &5, &BetSide::Down);
+
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 2_000u128); // price up
+
+    let alice_pay = client.get_pending_winnings(&alice);
+    let bob_pay = client.get_pending_winnings(&bob);
+    let charlie_pay = client.get_pending_winnings(&charlie);
+    let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+
+    assert_eq!(alice_pay, 5); // floor(3*12/7)
+    assert_eq!(bob_pay, 6); // floor(4*12/7)
+    assert_eq!(charlie_pay, 0);
+    assert_eq!(treasury_delta, 0);
+    assert_eq!(
+        alice_pay + bob_pay + charlie_pay + treasury_delta,
+        11,
+        "expected exactly 1 stroop of unavoidable floor-division slack"
+    );
+}
+
+/// Row 2 — fee enabled (10%), amounts chosen so every division is exact.
+/// Conservation must hold with **zero** slack: payouts + treasury == pot.
+#[test]
+fn updown_win_two_way_split_fee_enabled_exact_conservation() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let charlie = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+    client.mint_initial(&charlie);
+
+    client.create_round(&1_000u128, &None);
+    client.place_bet(&alice, &60, &BetSide::Up);
+    client.place_bet(&bob, &40, &BetSide::Up);
+    client.place_bet(&charlie, &100, &BetSide::Down);
+    set_fee_bps_now(&env, &contract_id, 1_000); // 10%
+
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 2_000u128); // price up
+
+    let alice_pay = client.get_pending_winnings(&alice);
+    let bob_pay = client.get_pending_winnings(&bob);
+    let charlie_pay = client.get_pending_winnings(&charlie);
+    let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+
+    assert_eq!(alice_pay, 108);
+    assert_eq!(bob_pay, 72);
+    assert_eq!(charlie_pay, 0);
+    assert_eq!(treasury_delta, 20);
+    assert_eq!(alice_pay + bob_pay + charlie_pay + treasury_delta, 200);
+}
+
+// ─── Row 3–4: UpDown refund paths ────────────────────────────────────────────
+
+/// Row 3 — price unchanged (tie): full refund, and a configured fee must
+/// never be charged on a non-competitive settlement.
+#[test]
+fn updown_tie_refund_ignores_configured_fee() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &None);
+    client.place_bet(&alice, &7, &BetSide::Up);
+    client.place_bet(&bob, &13, &BetSide::Down);
+    set_fee_bps_now(&env, &contract_id, 500);
+
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 1_000u128); // unchanged
+
+    assert_eq!(client.get_pending_winnings(&alice), 7);
+    assert_eq!(client.get_pending_winnings(&bob), 13);
+    assert_eq!(client.get_protocol_fee_treasury() - treasury_before, 0);
+}
+
+/// Row 4 — one-sided pool (only Up bets exist): refund regardless of price
+/// movement direction, and a configured fee must not apply.
+#[test]
+fn updown_one_sided_pool_ignores_configured_fee() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &None);
+    client.place_bet(&alice, &9, &BetSide::Up);
+    client.place_bet(&bob, &11, &BetSide::Up);
+    set_fee_bps_now(&env, &contract_id, 700);
+
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 2_000u128); // price up, but down pool is empty
+
+    assert_eq!(client.get_pending_winnings(&alice), 9);
+    assert_eq!(client.get_pending_winnings(&bob), 11);
+    assert_eq!(client.get_protocol_fee_treasury() - treasury_before, 0);
+}
+
+// ─── Row 5–6: UpDown cancel / fallback ("dispute-adjacent") paths ───────────
+
+/// Row 5 — admin cancellation: full refund, fee must not apply.
+#[test]
+fn updown_cancel_ignores_configured_fee() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &None);
+    client.place_bet(&alice, &15, &BetSide::Up);
+    client.place_bet(&bob, &25, &BetSide::Down);
+    set_fee_bps_now(&env, &contract_id, 700);
+
+    let treasury_before = client.get_protocol_fee_treasury();
+    client.cancel_round(&1u32);
+
+    assert_eq!(client.get_pending_winnings(&alice), 15);
+    assert_eq!(client.get_pending_winnings(&bob), 25);
+    assert_eq!(client.get_protocol_fee_treasury() - treasury_before, 0);
+    assert_eq!(client.get_active_round(), None);
+}
+
+/// Row 6 — insufficient participants at settlement: fallback refund, fee
+/// must not apply. Also pins the archived-round status code.
+#[test]
+fn updown_fallback_refund_ignores_configured_fee() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    client.mint_initial(&alice);
+
+    client.create_round(&1_000u128, &None);
+    client.place_bet(&alice, &17, &BetSide::Up);
+    client.set_min_participants(&Some(2u32));
+    set_fee_bps_now(&env, &contract_id, 300);
+
+    let round_id = client.get_active_round().unwrap().round_id;
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 1_001u128);
+
+    assert_eq!(client.get_pending_winnings(&alice), 17);
+    assert_eq!(client.get_protocol_fee_treasury() - treasury_before, 0);
+    assert_eq!(client.get_active_round(), None);
+    assert_eq!(
+        client.get_archived_round(&round_id).unwrap().status,
+        RoundArchiveStatus::FallbackRefund
+    );
+}
+
+// ─── Row 7–8: Precision wins ─────────────────────────────────────────────────
+
+/// Row 7 — single winner, fee disabled: winner takes the entire pot.
+#[test]
+fn precision_single_winner_fee_disabled_exact_conservation() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &Some(1));
+    client.place_precision_prediction(&alice, &50, &1_005u128);
+    client.place_precision_prediction(&bob, &30, &1_100u128);
+
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 1_006u128);
+
+    let alice_pay = client.get_pending_winnings(&alice);
+    let bob_pay = client.get_pending_winnings(&bob);
+    let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+
+    assert_eq!(alice_pay, 80);
+    assert_eq!(bob_pay, 0);
+    assert_eq!(treasury_delta, 0);
+    assert_eq!(alice_pay + bob_pay + treasury_delta, 80);
+}
+
+/// Row 8 — two-way tie with fee enabled (10%): remainder handling is exact
+/// (Precision mode assigns the leftover stroop to exactly one winner, so
+/// conservation holds with zero slack regardless of which winner it is).
+#[test]
+fn precision_tie_two_winners_fee_enabled_exact_remainder() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let charlie = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+    client.mint_initial(&charlie);
+
+    client.create_round(&1_000u128, &Some(1));
+    client.place_precision_prediction(&alice, &50, &1_005u128); // diff 5
+    client.place_precision_prediction(&bob, &50, &995u128); // diff 5 (tie)
+    client.place_precision_prediction(&charlie, &50, &1_200u128); // loses
+    set_fee_bps_now(&env, &contract_id, 1_000); // 10%
+
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 1_000u128);
+
+    let alice_pay = client.get_pending_winnings(&alice);
+    let bob_pay = client.get_pending_winnings(&bob);
+    let charlie_pay = client.get_pending_winnings(&charlie);
+    let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+
+    let (lo, hi) = if alice_pay < bob_pay {
+        (alice_pay, bob_pay)
+    } else {
+        (bob_pay, alice_pay)
+    };
+    assert_eq!(lo, 67);
+    assert_eq!(hi, 68);
+    assert_eq!(charlie_pay, 0);
+    assert_eq!(treasury_delta, 15);
+    assert_eq!(
+        alice_pay + bob_pay + charlie_pay + treasury_delta,
+        150,
+        "Precision conservation must be exact, even with an odd remainder"
+    );
+}
+
+// ─── Row 9–10: Precision commit-reveal interactions (the leak scenario) ────
+
+/// Row 9 — **regression guard**: nobody reveals. Before the fix in
+/// `settlement.rs::_resolve_precision_mode`, this branch had no refund path
+/// at all — every committed stroop vanished (0 payouts, 0 treasury, but a
+/// non-zero pot). This test fails immediately if that leak reappears.
+#[test]
+fn precision_all_unrevealed_refunds_ignores_configured_fee() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &Some(1));
+    let salt_a = test_salt(&env, 1);
+    let salt_b = test_salt(&env, 2);
+    client.commit_prediction(&alice, &make_commitment(&env, 1_005u128, &salt_a), &40);
+    client.commit_prediction(&bob, &make_commitment(&env, 995u128, &salt_b), &60);
+    set_fee_bps_now(&env, &contract_id, 500);
+
+    // Neither user reveals.
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 1_000u128);
+
+    let alice_pay = client.get_pending_winnings(&alice);
+    let bob_pay = client.get_pending_winnings(&bob);
+    let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+
+    assert_eq!(alice_pay, 40, "unrevealed stake must be refunded, not burned");
+    assert_eq!(bob_pay, 60, "unrevealed stake must be refunded, not burned");
+    assert_eq!(treasury_delta, 0, "fee must not apply on a refund path");
+    assert_eq!(alice_pay + bob_pay + treasury_delta, 100);
+}
+
+/// Row 10 — mixed reveal: Alice reveals and wins the full (fee-adjusted)
+/// pot; Bob never reveals and forfeits his stake to the pot rather than
+/// being refunded (anti-griefing incentive to reveal). Conservation is
+/// exact even though the two participants take very different paths.
+#[test]
+fn precision_mixed_reveal_forfeit_fee_enabled_exact_conservation() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &Some(1));
+    let salt_a = test_salt(&env, 3);
+    let salt_b = test_salt(&env, 4);
+    client.commit_prediction(&alice, &make_commitment(&env, 1_005u128, &salt_a), &40);
+    client.commit_prediction(&bob, &make_commitment(&env, 995u128, &salt_b), &60);
+    set_fee_bps_now(&env, &contract_id, 500); // 5%
+
+    env.ledger().with_mut(|li| li.sequence_number = 7); // reveal window opens at 6
+    client.reveal_prediction(&alice, &1_005u128, &salt_a);
+    // Bob deliberately never reveals.
+
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 1_006u128);
+
+    let alice_pay = client.get_pending_winnings(&alice);
+    let bob_pay = client.get_pending_winnings(&bob);
+    let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+
+    assert_eq!(alice_pay, 95); // (40 + 60) * 0.95, single winner, no remainder
+    assert_eq!(bob_pay, 0);
+    assert_eq!(treasury_delta, 5);
+    assert_eq!(alice_pay + bob_pay + treasury_delta, 100);
+}
+
+// ─── Row 11–12: Precision cancel / fallback ("dispute-adjacent") paths ─────
+
+/// Row 11 — admin cancellation with a mix of a revealed prediction and a
+/// still-committed (unrevealed) commitment: both must be refunded in full,
+/// and a configured fee must not apply.
+#[test]
+fn precision_cancel_mixed_reveal_ignores_configured_fee() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &Some(1));
+    let salt_a = test_salt(&env, 5);
+    let salt_b = test_salt(&env, 6);
+    client.commit_prediction(&alice, &make_commitment(&env, 1_005u128, &salt_a), &25);
+    client.commit_prediction(&bob, &make_commitment(&env, 995u128, &salt_b), &35);
+    set_fee_bps_now(&env, &contract_id, 600);
+
+    env.ledger().with_mut(|li| li.sequence_number = 7);
+    client.reveal_prediction(&alice, &1_005u128, &salt_a);
+    // Bob stays an unrevealed commitment.
+
+    let treasury_before = client.get_protocol_fee_treasury();
+    client.cancel_round(&2u32);
+
+    assert_eq!(client.get_pending_winnings(&alice), 25);
+    assert_eq!(client.get_pending_winnings(&bob), 35);
+    assert_eq!(client.get_protocol_fee_treasury() - treasury_before, 0);
+    assert_eq!(client.get_active_round(), None);
+}
+
+/// Row 12 — insufficient participants at settlement with a mix of a
+/// revealed prediction and an unrevealed commitment: both refunded, fee
+/// must not apply, archived status pinned.
+#[test]
+fn precision_fallback_refund_mixed_reveal_ignores_configured_fee() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint_initial(&alice);
+    client.mint_initial(&bob);
+
+    client.create_round(&1_000u128, &Some(1));
+    let salt_a = test_salt(&env, 7);
+    let salt_b = test_salt(&env, 8);
+    client.commit_prediction(&alice, &make_commitment(&env, 1_005u128, &salt_a), &10);
+    client.commit_prediction(&bob, &make_commitment(&env, 995u128, &salt_b), &20);
+    client.set_min_participants(&Some(3u32));
+    set_fee_bps_now(&env, &contract_id, 400);
+
+    env.ledger().with_mut(|li| li.sequence_number = 7);
+    client.reveal_prediction(&alice, &1_005u128, &salt_a);
+    // Bob stays an unrevealed commitment.
+
+    let round_id = client.get_active_round().unwrap().round_id;
+    env.ledger().with_mut(|li| li.sequence_number = 12);
+    let treasury_before = client.get_protocol_fee_treasury();
+    resolve_at(&env, &client, &contract_id, 1_000u128);
+
+    assert_eq!(client.get_pending_winnings(&alice), 10);
+    assert_eq!(client.get_pending_winnings(&bob), 20);
+    assert_eq!(client.get_protocol_fee_treasury() - treasury_before, 0);
+    assert_eq!(
+        client.get_archived_round(&round_id).unwrap().status,
+        RoundArchiveStatus::FallbackRefund
+    );
+}
+
+// ─── Small-random coverage on top of the fixed matrix ───────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+
+    /// UpDown mode across randomized pool sizes, fee bps, and settlement
+    /// direction (up/down/tie). Regardless of which branch fires (win,
+    /// tie-refund, or one-sided-refund), conservation must hold within the
+    /// documented floor-division slack bound (at most 1 stroop here, since
+    /// at most two bettors ever share the winning side).
+    #[test]
+    fn conservation_matrix_updown_small_random(
+        a_up in 1i128..=1_000i128,
+        b_up in 0i128..=1_000i128,
+        c_down in 0i128..=1_000i128,
+        fee_bps_raw in 0u32..=1_000u32,
+        direction in 0u8..=2u8, // 0 = down, 1 = tie, 2 = up
+    ) {
+        let env = Env::default();
+        let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let charlie = Address::generate(&env);
+        client.mint_initial(&alice);
+        client.mint_initial(&bob);
+        client.mint_initial(&charlie);
+
+        client.create_round(&1_000u128, &None);
+        client.place_bet(&alice, &a_up, &BetSide::Up);
+        if b_up > 0 {
+            client.place_bet(&bob, &b_up, &BetSide::Up);
+        }
+        if c_down > 0 {
+            client.place_bet(&charlie, &c_down, &BetSide::Down);
+        }
+        if fee_bps_raw > 0 {
+            set_fee_bps_now(&env, &contract_id, fee_bps_raw);
+        }
+
+        let total_pot = a_up + b_up + c_down;
+        let final_price = match direction {
+            0 => 900u128,
+            1 => 1_000u128,
+            _ => 1_100u128,
+        };
+
+        env.ledger().with_mut(|li| li.sequence_number = 12);
+        let treasury_before = client.get_protocol_fee_treasury();
+        resolve_at(&env, &client, &contract_id, final_price);
+
+        let alice_pay = client.get_pending_winnings(&alice);
+        let bob_pay = client.get_pending_winnings(&bob);
+        let charlie_pay = client.get_pending_winnings(&charlie);
+        let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+        let accounted = alice_pay + bob_pay + charlie_pay + treasury_delta;
+
+        prop_assert!(alice_pay >= 0);
+        prop_assert!(bob_pay >= 0);
+        prop_assert!(charlie_pay >= 0);
+        prop_assert!(treasury_delta >= 0);
+        prop_assert!(accounted <= total_pot,
+            "conservation upper bound violated: accounted={} pot={}", accounted, total_pot);
+        prop_assert!(accounted >= total_pot - 1,
+            "leak beyond documented 1-stroop floor-division slack: accounted={} pot={}",
+            accounted, total_pot);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+
+    /// Precision mode across randomized amounts, predicted prices, final
+    /// price, fee bps, and — crucially — whether each of the two
+    /// participants reveals at all. This directly randomizes the exact
+    /// interaction that produced the all-/mixed-unrevealed leak, so
+    /// conservation is asserted **exactly** (Precision mode has no
+    /// multi-winner truncation slack: the remainder always goes to a single
+    /// winner, and refund paths return every stroop).
+    #[test]
+    fn conservation_matrix_precision_small_random(
+        amount_a in 1i128..=1_000i128,
+        amount_b in 1i128..=1_000i128,
+        price_a in 1u128..=99_999_998u128,
+        price_b in 1u128..=99_999_998u128,
+        final_price in 1u128..=99_999_998u128,
+        fee_bps_raw in 0u32..=1_000u32,
+        reveal_a in any::<bool>(),
+        reveal_b in any::<bool>(),
+    ) {
+        let env = Env::default();
+        let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint_initial(&alice);
+        client.mint_initial(&bob);
+
+        client.create_round(&1_000_000u128, &Some(1));
+        let salt_a = test_salt(&env, 101);
+        let salt_b = test_salt(&env, 102);
+        client.commit_prediction(&alice, &make_commitment(&env, price_a, &salt_a), &amount_a);
+        client.commit_prediction(&bob, &make_commitment(&env, price_b, &salt_b), &amount_b);
+        if fee_bps_raw > 0 {
+            set_fee_bps_now(&env, &contract_id, fee_bps_raw);
+        }
+
+        env.ledger().with_mut(|li| li.sequence_number = 7);
+        if reveal_a {
+            client.reveal_prediction(&alice, &price_a, &salt_a);
+        }
+        if reveal_b {
+            client.reveal_prediction(&bob, &price_b, &salt_b);
+        }
+
+        env.ledger().with_mut(|li| li.sequence_number = 12);
+        let treasury_before = client.get_protocol_fee_treasury();
+        resolve_at(&env, &client, &contract_id, final_price);
+
+        let alice_pay = client.get_pending_winnings(&alice);
+        let bob_pay = client.get_pending_winnings(&bob);
+        let treasury_delta = client.get_protocol_fee_treasury() - treasury_before;
+        let total_pot = amount_a + amount_b;
+
+        prop_assert!(alice_pay >= 0);
+        prop_assert!(bob_pay >= 0);
+        prop_assert!(treasury_delta >= 0);
+        prop_assert_eq!(
+            alice_pay + bob_pay + treasury_delta,
+            total_pot,
+            "Precision conservation must be exact: alice={} bob={} treasury_delta={} pot={} reveal_a={} reveal_b={}",
+            alice_pay, bob_pay, treasury_delta, total_pot, reveal_a, reveal_b
+        );
+
+        if !reveal_a && !reveal_b {
+            prop_assert_eq!(treasury_delta, 0, "no winner exists to be charged a fee against");
+        }
+    }
+}

--- a/contracts/src/tests/leaderboard_seasons.rs
+++ b/contracts/src/tests/leaderboard_seasons.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+//! Tests for seasonal leaderboards: season-scoped stats independent of the
+//! lifetime leaderboard, archive-on-reset, scoped queries, and boundaries.
+
+use crate::contract::{VirtualTokenContract, VirtualTokenContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup_contract(env: &Env) -> (VirtualTokenContractClient<'_>, Address, Address, Address) {
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    (client, contract_id, admin, oracle)
+}
+
+fn win(env: &Env, contract_id: &Address, user: &Address) {
+    env.as_contract(contract_id, || {
+        VirtualTokenContract::_update_stats_win(env, user.clone()).unwrap();
+    });
+}
+
+fn lose(env: &Env, contract_id: &Address, user: &Address) {
+    env.as_contract(contract_id, || {
+        VirtualTokenContract::_update_stats_loss(env, user.clone()).unwrap();
+    });
+}
+
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_season_defaults_to_one_and_starts_empty() {
+    let env = Env::default();
+    let (client, _cid, _admin, _oracle) = setup_contract(&env);
+
+    assert_eq!(client.get_current_season_id(), 1);
+    assert_eq!(client.get_season_leaderboard_by_wins(&1, &0, &10).len(), 0);
+    assert_eq!(client.get_season_leaderboard_by_streak(&1, &0, &10).len(), 0);
+
+    let alice = Address::generate(&env);
+    let stats = client.get_season_user_stats(&1, &alice);
+    assert_eq!(stats.total_wins, 0);
+    assert_eq!(stats.total_losses, 0);
+    assert_eq!(stats.current_streak, 0);
+    assert_eq!(stats.best_streak, 0);
+}
+
+// ─── Season-scoped stats independent of lifetime stats ────────────────────────
+
+#[test]
+fn test_season_stats_track_alongside_lifetime_stats() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+    let alice = Address::generate(&env);
+
+    win(&env, &contract_id, &alice);
+    win(&env, &contract_id, &alice);
+    lose(&env, &contract_id, &alice);
+
+    let lifetime = client.get_user_stats(&alice);
+    let season = client.get_season_user_stats(&1, &alice);
+
+    assert_eq!(lifetime.total_wins, 2);
+    assert_eq!(lifetime.total_losses, 1);
+    assert_eq!(lifetime.best_streak, 2);
+    assert_eq!(lifetime.current_streak, 0);
+
+    // With only season 1 ever active, season-scoped and lifetime counters
+    // agree exactly — the two ledgers are independent, not linked.
+    assert_eq!(season.total_wins, lifetime.total_wins);
+    assert_eq!(season.total_losses, lifetime.total_losses);
+    assert_eq!(season.best_streak, lifetime.best_streak);
+    assert_eq!(season.current_streak, lifetime.current_streak);
+}
+
+// ─── Ordering and pagination ──────────────────────────────────────────────────
+
+#[test]
+fn test_season_leaderboard_ordering_and_pagination() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    for _ in 0..3 {
+        win(&env, &contract_id, &alice);
+    }
+    for _ in 0..5 {
+        win(&env, &contract_id, &bob);
+    }
+    for _ in 0..2 {
+        win(&env, &contract_id, &carol);
+    }
+
+    let page = client.get_season_leaderboard_by_wins(&1, &0, &10);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap().user, bob);
+    assert_eq!(page.get(0).unwrap().wins, 5);
+    assert_eq!(page.get(1).unwrap().user, alice);
+    assert_eq!(page.get(1).unwrap().wins, 3);
+    assert_eq!(page.get(2).unwrap().user, carol);
+    assert_eq!(page.get(2).unwrap().wins, 2);
+
+    // offset 1, limit 1 -> Alice only.
+    let page = client.get_season_leaderboard_by_wins(&1, &1, &1);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page.get(0).unwrap().user, alice);
+}
+
+// ─── Archive on reset, scoped queries, lifetime untouched ──────────────────────
+
+/// Covers all three acceptance criteria at once: archives are preserved,
+/// queries stay scoped to the season they name, and the lifetime leaderboard
+/// is never wiped by a season reset.
+#[test]
+fn test_reset_season_archives_scopes_queries_and_preserves_lifetime_history() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    for _ in 0..3 {
+        win(&env, &contract_id, &alice);
+    }
+    for _ in 0..5 {
+        win(&env, &contract_id, &bob);
+    }
+
+    let new_season_id = client.reset_leaderboard_season();
+    assert_eq!(new_season_id, 2);
+    assert_eq!(client.get_current_season_id(), 2);
+
+    // Archive preserved: season 1's frozen ranking is retrievable directly...
+    let archive = client.get_season_archive(&1).expect("season 1 must be archived");
+    assert_eq!(archive.season_id, 1);
+    assert_eq!(archive.participant_count, 2);
+    assert_eq!(archive.wins.len(), 2);
+    assert_eq!(archive.wins.get(0).unwrap().user, bob);
+    assert_eq!(archive.wins.get(0).unwrap().wins, 5);
+    assert_eq!(archive.wins.get(1).unwrap().user, alice);
+    assert_eq!(archive.wins.get(1).unwrap().wins, 3);
+
+    // ...and transparently through the same paginated query used for the
+    // live leaderboard, now routed to the frozen snapshot.
+    let season1_page = client.get_season_leaderboard_by_wins(&1, &0, &10);
+    assert_eq!(season1_page.len(), 2);
+    assert_eq!(season1_page.get(0).unwrap().user, bob);
+    assert_eq!(season1_page.get(0).unwrap().wins, 5);
+
+    // Queries scoped: the new active season starts completely empty.
+    let season2_page = client.get_season_leaderboard_by_wins(&2, &0, &10);
+    assert_eq!(season2_page.len(), 0);
+
+    // A fresh win in season 2 only affects season 2's ranking and stats —
+    // season 1's frozen numbers for the same user are untouched.
+    win(&env, &contract_id, &alice);
+    assert_eq!(client.get_season_user_stats(&2, &alice).total_wins, 1);
+    assert_eq!(client.get_season_user_stats(&1, &alice).total_wins, 3);
+
+    let season2_page = client.get_season_leaderboard_by_wins(&2, &0, &10);
+    assert_eq!(season2_page.len(), 1);
+    assert_eq!(season2_page.get(0).unwrap().user, alice);
+    assert_eq!(season2_page.get(0).unwrap().wins, 1);
+
+    // Lifetime history is never wiped by the reset: it reflects every win
+    // across both seasons combined (Bob=5, Alice=3+1=4).
+    let lifetime_page = client.get_leaderboard_by_wins(&0, &10);
+    assert_eq!(lifetime_page.len(), 2);
+    assert_eq!(lifetime_page.get(0).unwrap().user, bob);
+    assert_eq!(lifetime_page.get(0).unwrap().stats.total_wins, 5);
+    assert_eq!(lifetime_page.get(1).unwrap().user, alice);
+    assert_eq!(lifetime_page.get(1).unwrap().stats.total_wins, 4);
+}
+
+// ─── Boundary tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_season_boundary_unknown_and_zero_season_ids_return_empty() {
+    let env = Env::default();
+    let (client, _cid, _admin, _oracle) = setup_contract(&env);
+
+    // Season 0 never existed (seasons start at 1).
+    assert_eq!(client.get_season_leaderboard_by_wins(&0, &0, &10).len(), 0);
+    assert_eq!(client.get_season_leaderboard_by_streak(&0, &0, &10).len(), 0);
+    assert!(client.get_season_archive(&0).is_none());
+
+    // A season far beyond anything ever reset.
+    assert_eq!(client.get_season_leaderboard_by_wins(&999, &0, &10).len(), 0);
+    assert!(client.get_season_archive(&999).is_none());
+}
+
+#[test]
+fn test_season_boundary_reset_with_zero_participants() {
+    let env = Env::default();
+    let (client, _cid, _admin, _oracle) = setup_contract(&env);
+
+    // Nobody has ever won or lost — reset must still succeed and advance.
+    let new_season_id = client.reset_leaderboard_season();
+    assert_eq!(new_season_id, 2);
+
+    let archive = client.get_season_archive(&1).expect("empty season must still archive");
+    assert_eq!(archive.participant_count, 0);
+    assert_eq!(archive.wins.len(), 0);
+    assert_eq!(archive.streak.len(), 0);
+}
+
+#[test]
+fn test_season_boundary_pagination_offset_at_and_beyond_total() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    win(&env, &contract_id, &alice);
+
+    // offset == total -> empty, not an error.
+    assert_eq!(client.get_season_leaderboard_by_wins(&1, &1, &10).len(), 0);
+    // offset beyond total -> empty.
+    assert_eq!(client.get_season_leaderboard_by_wins(&1, &50, &10).len(), 0);
+    // limit larger than remaining entries returns only what exists.
+    assert_eq!(client.get_season_leaderboard_by_wins(&1, &0, &100).len(), 1);
+}
+
+#[test]
+fn test_season_boundary_consecutive_resets_keep_independent_archives() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _oracle) = setup_contract(&env);
+
+    // Season 1: nobody plays.
+    assert_eq!(client.reset_leaderboard_season(), 2);
+
+    // Season 2: Bob wins once.
+    let bob = Address::generate(&env);
+    win(&env, &contract_id, &bob);
+    assert_eq!(client.reset_leaderboard_season(), 3);
+
+    assert_eq!(client.get_current_season_id(), 3);
+
+    // Both prior archives remain independently correct — the second reset
+    // must not have overwritten or merged into the first.
+    let archive1 = client.get_season_archive(&1).unwrap();
+    assert_eq!(archive1.participant_count, 0);
+    assert_eq!(archive1.wins.len(), 0);
+
+    let archive2 = client.get_season_archive(&2).unwrap();
+    assert_eq!(archive2.participant_count, 1);
+    assert_eq!(archive2.wins.get(0).unwrap().user, bob);
+    assert_eq!(archive2.wins.get(0).unwrap().wins, 1);
+
+    // Season 3 (active) is empty.
+    assert_eq!(client.get_season_leaderboard_by_wins(&3, &0, &10).len(), 0);
+}

--- a/contracts/src/tests/lifecycle.rs
+++ b/contracts/src/tests/lifecycle.rs
@@ -974,3 +974,211 @@ fn test_cross_round_mode_alternation() {
     // Bob:   1000 - 50(R1) + 0 - 150(R2) + 0 - 100(R3) + 0 = 700
     assert_eq!(client.balance(&bob), 700_0000000);
 }
+
+// ─── Round templates / create-next keeper ────────────────────────────────────
+
+/// Set → get → clear round-trip, plus the same validation `create_round`
+/// itself applies (invalid start price, invalid mode).
+#[test]
+fn test_round_template_set_get_clear_and_validation() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    assert_eq!(client.get_round_template(), None);
+
+    // Invalid start price (0) is rejected, same as create_round.
+    let result = client.try_set_round_template(&0u128, &None);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStartPrice)));
+
+    // Invalid start price (over max) is rejected.
+    let result = client.try_set_round_template(&u128::MAX, &None);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStartPrice)));
+
+    // Invalid mode (only 0/1 allowed) is rejected.
+    let result = client.try_set_round_template(&1_0000000u128, &Some(2));
+    assert_eq!(result, Err(Ok(ContractError::InvalidMode)));
+
+    // No template was persisted by any of the rejected attempts.
+    assert_eq!(client.get_round_template(), None);
+
+    // Valid template is stored and readable.
+    client.set_round_template(&1_5000000u128, &Some(1));
+    let template = client.get_round_template().expect("template must be set");
+    assert_eq!(template.start_price, 1_5000000u128);
+    assert_eq!(template.mode, Some(1));
+
+    // A later valid call overwrites the previous template.
+    client.set_round_template(&2_0000000u128, &None);
+    let template = client.get_round_template().expect("template must be set");
+    assert_eq!(template.start_price, 2_0000000u128);
+    assert_eq!(template.mode, None);
+
+    // Clearing removes it; clearing again with nothing configured errors.
+    client.clear_round_template();
+    assert_eq!(client.get_round_template(), None);
+    let result = client.try_clear_round_template();
+    assert_eq!(result, Err(Ok(ContractError::NoRoundTemplate)));
+}
+
+/// `create_next_from_template` requires a template to be configured first.
+#[test]
+fn test_create_next_from_template_requires_template() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    let result = client.try_create_next_from_template();
+    assert_eq!(result, Err(Ok(ContractError::NoRoundTemplate)));
+    assert_eq!(client.get_active_round(), None);
+}
+
+/// Acceptance: overlap is impossible. With a round already active,
+/// `create_next_from_template` must fail exactly like `create_round` would,
+/// and must not disturb the round that is already running.
+#[test]
+fn test_create_next_from_template_overlap_impossible() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    client.set_round_template(&3_0000000u128, &Some(0));
+    client.create_round(&1_0000000u128, &None);
+    let existing_round = client.get_active_round().expect("round should exist");
+
+    let result = client.try_create_next_from_template();
+    assert_eq!(result, Err(Ok(ContractError::RoundAlreadyActive)));
+
+    // The active round is exactly the one that already existed — untouched.
+    let round_after = client.get_active_round().expect("round should still exist");
+    assert_eq!(round_after, existing_round);
+}
+
+/// Acceptance: settle → next. After a round resolves normally, the keeper
+/// call creates the next round from the template with no manual
+/// parameters, and emits both `("round", "created")` and
+/// `("template", "applied")`.
+#[test]
+fn test_create_next_from_template_after_settle() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+    client.mint_initial(&alice);
+
+    client.set_round_template(&2_5000000u128, &Some(1));
+
+    client.create_round(&1_0000000u128, &None);
+    let round1 = client.get_active_round().unwrap();
+    client.place_bet(&alice, &100_0000000, &BetSide::Up);
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = round1.end_ledger;
+    });
+    client.resolve_round(&OraclePayload {
+        price: 1_5000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: round1.start_ledger,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(client.get_active_round(), None);
+
+    let next_round_id = client.create_next_from_template();
+    assert_eq!(next_round_id, round1.round_id + 1);
+
+    let round2 = client.get_active_round().expect("template round must be active");
+    assert_eq!(round2.round_id, next_round_id);
+    assert_eq!(round2.price_start, 2_5000000u128);
+    assert_eq!(round2.mode, RoundMode::Precision);
+
+    let events = env.events().all();
+    let created_event = events.iter().any(|e| {
+        let (_c, topics, _d) = e;
+        topics.len() == 2
+            && topics.get(0).unwrap().try_into_val(&env) == Ok(symbol_short!("round"))
+            && topics.get(1).unwrap().try_into_val(&env) == Ok(symbol_short!("created"))
+    });
+    let applied_event = events.iter().any(|e| {
+        let (_c, topics, _d) = e;
+        topics.len() == 2
+            && topics.get(0).unwrap().try_into_val(&env) == Ok(symbol_short!("template"))
+            && topics.get(1).unwrap().try_into_val(&env) == Ok(symbol_short!("applied"))
+    });
+    assert!(created_event, "create_next_from_template must emit round/created");
+    assert!(applied_event, "create_next_from_template must emit template/applied");
+}
+
+/// Acceptance: cancel → next. After an admin cancellation, the keeper call
+/// creates the next round from the template.
+#[test]
+fn test_create_next_from_template_after_cancel() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    client.set_round_template(&4_0000000u128, &None);
+
+    client.create_round(&1_0000000u128, &None);
+    let round1 = client.get_active_round().unwrap();
+    client.cancel_round(&1u32);
+    assert_eq!(client.get_active_round(), None);
+
+    let next_round_id = client.create_next_from_template();
+    assert_eq!(next_round_id, round1.round_id + 1);
+
+    let round2 = client.get_active_round().expect("template round must be active");
+    assert_eq!(round2.round_id, next_round_id);
+    assert_eq!(round2.price_start, 4_0000000u128);
+    assert_eq!(round2.mode, RoundMode::UpDown);
+}
+
+/// A cleared template can no longer be used to create the next round, even
+/// after a settle/cancel that would otherwise permit it.
+#[test]
+fn test_create_next_from_template_after_clear_fails() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    client.set_round_template(&1_0000000u128, &None);
+    client.create_round(&1_0000000u128, &None);
+    client.cancel_round(&1u32);
+    client.clear_round_template();
+
+    let result = client.try_create_next_from_template();
+    assert_eq!(result, Err(Ok(ContractError::NoRoundTemplate)));
+    assert_eq!(client.get_active_round(), None);
+}

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod chaos_recovery;
 mod commit_reveal_e2e;
 mod config_helpers;
 // mod config_timelock; // upstream bug
+mod conservation;
 mod cost_benchmarks;
 mod edge_cases;
 mod event_coverage;

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -15,6 +15,8 @@ mod event_coverage;
 mod guard_tests;
 // mod initialization; // upstream bug
 // mod invariant_harness; // upstream bug: uses std HashMap in no_std context
+mod leaderboard;
+mod leaderboard_seasons;
 mod lifecycle;
 mod migration_versioning;
 mod mode_tests;

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -138,6 +138,10 @@ pub enum DataKey {
     /// retained on-chain before the oldest are pruned (FIFO). If unset, the protocol
     /// default is used.
     ArchiveRetention,
+    /// Admin-configured blueprint used by `create_next_from_template` to spin
+    /// up the next round without re-specifying `start_price` / `mode` each
+    /// time. Absent means no template is configured.
+    RoundTemplate,
 }
 
 /// Identifies which critical risk setting is pending timelocked activation.
@@ -516,4 +520,17 @@ pub struct SimulationResult {
     pub precision_total_stake: i128,
     pub fee_amount: i128,
     pub outcomes: Vec<UserRoundOutcome>,
+}
+
+/// Admin-configured blueprint for `create_next_from_template`.
+///
+/// Mirrors the arguments accepted by `create_round` (`start_price`, `mode`)
+/// so a keeper can spin up the next round after a settle/cancel without an
+/// operator re-specifying parameters each time. Validated with the exact
+/// same rules `create_round` applies at creation time.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoundTemplate {
+    pub start_price: u128,
+    pub mode: Option<u32>,
 }

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -142,6 +142,28 @@ pub enum DataKey {
     /// up the next round without re-specifying `start_price` / `mode` each
     /// time. Absent means no template is configured.
     RoundTemplate,
+    /// Bounded index of user addresses sorted by lifetime total wins
+    /// descending (all-time leaderboard, independent of seasons).
+    LeaderboardWins,
+    /// Bounded index of user addresses sorted by lifetime best streak
+    /// descending (all-time leaderboard, independent of seasons).
+    LeaderboardStreak,
+    /// Monotonically increasing id of the currently-active leaderboard
+    /// season. Absent is treated as season 1.
+    SeasonId,
+    /// Per-season, per-user win/loss/streak stats: (season_id, address) →
+    /// UserStats, scoped independently of the lifetime `UserStats` totals so
+    /// a season reset never touches lifetime history.
+    SeasonUserStats(u32, Address),
+    /// Bounded index of user addresses in the *active* season sorted by
+    /// season-scoped total wins descending.
+    SeasonLeaderboardWins,
+    /// Bounded index of user addresses in the *active* season sorted by
+    /// season-scoped best streak descending.
+    SeasonLeaderboardStreak,
+    /// Frozen snapshot of a season's final rankings, written when the season
+    /// is reset. Seasons are never deleted — this is a permanent archive.
+    SeasonArchive(u32),
 }
 
 /// Identifies which critical risk setting is pending timelocked activation.
@@ -533,4 +555,36 @@ pub struct SimulationResult {
 pub struct RoundTemplate {
     pub start_price: u128,
     pub mode: Option<u32>,
+}
+
+/// A single entry in the lifetime (all-time) leaderboard.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct LeaderboardEntry {
+    pub user: Address,
+    pub stats: UserStats,
+}
+
+/// A single entry in a season-scoped leaderboard, live or archived.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SeasonLeaderboardEntry {
+    pub user: Address,
+    pub wins: u32,
+    pub best_streak: u32,
+}
+
+/// Frozen snapshot of a season's final bounded rankings, written by
+/// `reset_leaderboard_season`. `participant_count` is the number of distinct
+/// addresses that appeared in either bounded index at reset time (a lower
+/// bound on total season participants beyond the tracked top
+/// `LEADERBOARD_LIMIT`, mirroring the same bound the live indexes enforce).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SeasonArchive {
+    pub season_id: u32,
+    pub ended_at_ledger: u32,
+    pub wins: Vec<SeasonLeaderboardEntry>,
+    pub streak: Vec<SeasonLeaderboardEntry>,
+    pub participant_count: u32,
 }

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -413,6 +413,74 @@ refunds, so no new authorization surface is added.
 
 ---
 
+## `("template", "set")` — Round template stored
+
+Emitted when the admin stores or overwrites the round-creation blueprint
+used by `create_next_from_template`.
+
+| Field         | Type          | Description                                    |
+|---------------|---------------|-------------------------------------------------|
+| `start_price` | `u128`        | Starting price the next round will use.         |
+| `mode`        | `u32`         | Round mode: `0` = UpDown, `1` = Precision.       |
+
+**Topics**: `("template", "set")`
+**Source contracts**: `VirtualTokenContract`
+**Emitted by**: `set_round_template`.
+
+---
+
+## `("template", "cleared")` — Round template removed
+
+Emitted when the admin clears the configured round template.
+
+| Field     | Type  | Description                                  |
+|-----------|-------|-----------------------------------------------|
+| `ledger`  | `u32` | Ledger sequence number at which it was cleared.|
+
+**Topics**: `("template", "cleared")`
+**Source contracts**: `VirtualTokenContract`
+**Emitted by**: `clear_round_template`.
+
+---
+
+## `("template", "applied")` — Next round created from template
+
+Emitted when `create_next_from_template` successfully creates a round from
+the stored blueprint. Always accompanied by a `("round", "created")` event
+from the underlying `create_round` call.
+
+| Field         | Type   | Description                                   |
+|---------------|--------|------------------------------------------------|
+| `round_id`    | `u64`  | Id of the newly created round.                  |
+| `start_price` | `u128` | Starting price used (from the template).        |
+| `mode`        | `u32`  | Round mode used: `0` = UpDown, `1` = Precision. |
+
+**Topics**: `("template", "applied")`
+**Source contracts**: `VirtualTokenContract`
+**Emitted by**: `create_next_from_template`.
+
+---
+
+## `("season", "reset")` — Leaderboard season archived and advanced
+
+Emitted when the admin resets the active leaderboard season. The ending
+season's bounded rankings are frozen into a permanent `SeasonArchive` before
+the season id advances; per-user season stats (`SeasonUserStats`) for the
+ended season are never deleted and remain independently queryable.
+
+| Field               | Type  | Description                                          |
+|---------------------|-------|-------------------------------------------------------|
+| `season_id`         | `u32` | Id of the season that was just archived.               |
+| `new_season_id`     | `u32` | Id of the newly-active season (`season_id + 1`).        |
+| `ended_at_ledger`    | `u32` | Ledger sequence number at which the season ended.       |
+| `participant_count` | `u32` | Distinct addresses present in the archived rankings.    |
+
+**Topics**: `("season", "reset")`
+**Source contracts**: `VirtualTokenContract`
+**Emitted by**: `reset_leaderboard_season`.
+
+---
+
 ---
 
 ## Field units quick reference


### PR DESCRIPTION
## Summary

- **Conservation invariant matrix** (`contracts/src/tests/conservation.rs`): fixed +
  small-random property tests pinning stroop-level conservation
  (`payouts + treasury_delta == pot`) across the full UpDown/Precision ×
  fee-on/off × win/tie/one-sided/cancel/fallback-refund matrix. While
  building it, found and fixed a real leak in
  `_resolve_precision_mode`: when nobody reveals a Precision
  commitment, staked amounts were silently dropped (no refund, no fee,
  no winner) instead of being refunded.
- **Round templates / create-next keeper** (`set_round_template`,
  `clear_round_template`, `create_next_from_template`): lets an admin
  store a `(start_price, mode)` blueprint once, then have a keeper spin
  up the next round after every settle/cancel without re-supplying
  parameters. Round creation is delegated to the existing `create_round`,
  so the single-active-round guard is inherited verbatim — overlap is
  structurally impossible rather than re-checked separately.
- **Leaderboard seasons with archive-on-reset**: revives the lifetime
  (all-time) wins/streak leaderboard that was dropped during a prior
  modularization pass, and layers a seasonal leaderboard on top.
  `SeasonUserStats(season_id, user)` tracks stats scoped to one season,
  entirely independent of lifetime totals. `reset_leaderboard_season`
  (admin only) freezes the active season's rankings into a permanent
  `SeasonArchive` and advances the season id — nothing is ever deleted,
  so past-season queries transparently fall back to the frozen archive.

Closes #305 
Closes #306 
Closes #307 