### PR TITLE
#297 Bindings: typed SDK helpers + error mapping

### DIFF
--- a/bindings/README.md
+++ b/bindings/README.md
@@ -142,6 +142,25 @@ if (claimed) {
 }
 ```
 
+## `simulateBet`
+
+Simulates a bet without broadcasting to estimate resource fees and decode errors.
+
+```ts
+import { simulateBet } from "@xelma/bindings/helpers"
+
+const { simulated, minResourceFee, error } = await simulateBet(client, {
+  user: "GABCDEF123...",
+  amount: 500_000_000n,
+  side: { tag: "Up", values: undefined },
+})
+if (simulated) {
+  console.log(`Estimated min resource fee: ${minResourceFee}`)
+} else {
+  console.error("Simulation failed:", error)
+}
+```
+
 ## Error reference
 
 | Exception                  | Contract code | Meaning                          |
@@ -152,6 +171,7 @@ if (claimed) {
 | `AlreadyBetError`          | 10            | User already bet in this round   |
 | `StakeExceedsMaxError`     | 28            | Bet exceeds the max stake cap    |
 | `ExposureCapExceededError` | 29            | User exposure exceeds round cap  |
+| `NoRoundTemplateError`     | 65            | No round template configured     |
 
 All typed exceptions extend `XelmaError` (which extends `Error`), so you
 can catch specific types or the base class.

--- a/bindings/package-lock.json
+++ b/bindings/package-lock.json
@@ -2025,6 +2025,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/bindings/src/helpers.ts
+++ b/bindings/src/helpers.ts
@@ -63,6 +63,13 @@ export class ExposureCapExceededError extends XelmaError {
   }
 }
 
+export class NoRoundTemplateError extends XelmaError {
+  constructor() {
+    super("No round template configured", 65, "NoRoundTemplate");
+    this.name = "NoRoundTemplateError";
+  }
+}
+
 // ─── Error Mapping ─────────────────────────────────────────────
 
 const ERROR_CODE_TO_CLASS: Record<number, new () => XelmaError> = {
@@ -72,6 +79,7 @@ const ERROR_CODE_TO_CLASS: Record<number, new () => XelmaError> = {
   22: ContractPausedError,
   28: StakeExceedsMaxError,
   29: ExposureCapExceededError,
+  65: NoRoundTemplateError,
 };
 
 /**
@@ -213,4 +221,43 @@ export async function claimIfPending(
   }
 
   return { claimed: false };
+}
+
+// ─── Simulate Helper ───────────────────────────────────────────
+
+export interface SimulateBetResult {
+  simulated: boolean;
+  minResourceFee?: string;
+  error?: Error;
+}
+
+/**
+ * Simulates placing a bet without broadcasting to inspect expected outcome,
+ * resource fee estimation, and decode any contract errors.
+ *
+ * @example
+ * const { simulated, minResourceFee, error } = await simulateBet(client, {
+ *   user: "GABCDEF123...",
+ *   amount: 500_000_000n,
+ *   side: { tag: "Up", values: undefined },
+ * })
+ */
+export async function simulateBet(
+  client: Client,
+  params: PlaceBetParams,
+  options?: MethodOptions,
+): Promise<SimulateBetResult> {
+  try {
+    const betTx = await client.place_bet(params, options);
+    const simulatedTx = await betTx.simulate();
+    return {
+      simulated: true,
+      minResourceFee: (simulatedTx as any).minResourceFee,
+    };
+  } catch (err) {
+    return {
+      simulated: false,
+      error: wrapContractError(err),
+    };
+  }
 }

--- a/bindings/tests/integration.test.ts
+++ b/bindings/tests/integration.test.ts
@@ -3,6 +3,7 @@ import {
   mintIfNeeded,
   placeBetChecked,
   claimIfPending,
+  simulateBet,
   XelmaError,
   InsufficientBalanceError,
   NoActiveRoundError,
@@ -10,10 +11,12 @@ import {
   AlreadyBetError,
   StakeExceedsMaxError,
   ExposureCapExceededError,
+  NoRoundTemplateError,
   wrapContractError,
   type MintResult,
   type ClaimResult,
   type PlaceBetParams,
+  type SimulateBetResult,
 } from "../src/helpers.js";
 
 // ─── Helpers ───────────────────────────────────────────────────
@@ -203,6 +206,45 @@ describe("wrapContractError", () => {
     const err = wrapContractError({ code: 29 });
     expect(err).toBeInstanceOf(ExposureCapExceededError);
   });
+
+  it("passes through NoRoundTemplateError for code 65", () => {
+    const err = wrapContractError({ code: 65 });
+    expect(err).toBeInstanceOf(NoRoundTemplateError);
+  });
+});
+
+// ─── simulateBet ───────────────────────────────────────────────
+
+describe("simulateBet", () => {
+  it("returns simulated=true and minResourceFee on success", async () => {
+    const client = createMockClient();
+    client.place_bet.mockResolvedValue({
+      simulate: vi.fn().mockResolvedValue({ minResourceFee: "100" }),
+    });
+
+    const result = await simulateBet(client, {
+      user: "GABC",
+      amount: 100n,
+      side: { tag: "Up", values: undefined },
+    });
+
+    expect(result.simulated).toBe(true);
+    expect(result.minResourceFee).toBe("100");
+  });
+
+  it("returns simulated=false and wrapped error on simulation failure", async () => {
+    const client = createMockClient();
+    client.place_bet.mockRejectedValue({ code: 22 });
+
+    const result = await simulateBet(client, {
+      user: "GABC",
+      amount: 100n,
+      side: { tag: "Up", values: undefined },
+    });
+
+    expect(result.simulated).toBe(false);
+    expect(result.error).toBeInstanceOf(ContractPausedError);
+  });
 });
 
 // ─── Type exports ──────────────────────────────────────────────
@@ -225,5 +267,10 @@ describe("type exports", () => {
       side: { tag: "Down", values: undefined },
     };
     expect(p.side.tag).toBe("Down");
+  });
+
+  it("SimulateBetResult has expected shape", () => {
+    const s: SimulateBetResult = { simulated: true, minResourceFee: "100" };
+    expect(s.simulated).toBe(true);
   });
 });

--- a/docs/WALLET_ERROR_GUIDE.md
+++ b/docs/WALLET_ERROR_GUIDE.md
@@ -55,6 +55,7 @@ This guide maps each smart‑contract error defined in `contracts/src/errors.rs`
 | `0x30` | 48 | InvalidPrecisionParticipantCap | Precision participant cap is out of range (must be 1–10000) | "Invalid precision participant cap."
 | `0x3f` | 63 | InvalidCommitment | Commitment hash is malformed (e.g. all-zero placeholder) | "Invalid commitment hash."
 | `0x40` | 64 | InvalidSalt | Reveal salt fails minimum entropy rules | "Invalid reveal salt."
+| `0x41` | 65 | NoRoundTemplate | No round template configured | "No round template."
 
 ## Integration Walkthroughs
 ### 1. Handling errors in a Freighter wallet


### PR DESCRIPTION
## Problem
Closes #297 
Raw generated Soroban client calls leave integrators to manually decode numerical error codes and handle pre-flight checks manually, introducing integrator bugs and raw error code leakage into user interfaces.

## Solution
- Added \simulateBet\ helper to pre-flight test bet transactions without broadcasting and return decoded error messages or resource fee estimates.
- Added \NoRoundTemplateError\ typed exception class (contract error code 65) to \indings/src/helpers.ts\.
- Added unit tests for \simulateBet\, \NoRoundTemplateError\, and error decoding in \indings/tests/integration.test.ts\ (23 tests passing).
- Documented \simulateBet\ and \NoRoundTemplateError\ in \indings/README.md\ and \docs/WALLET_ERROR_GUIDE.md\.

## Acceptance Criteria
- [x] Helpers tested (\
pm run test:vitest\ 23/23 passing)
- [x] README examples updated with \simulateBet\ and \NoRoundTemplateError\
- [x] Generated client unbroken