### PR TITLE
Oracle rotation mandatory delay + public notice events (Close #273)

### DIFF
--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -33,6 +33,10 @@ const MAX_ORACLE_STALE_THRESHOLD: u64 = 86_400; // 24 hours
 
 // ─── Oracle rotation expiry ───────────────────────────────────────────────────
 const MIN_ROTATION_EXPIRY_SECONDS: u64 = 60; // 1 minute minimum
+/// Minimum delay between proposing and accepting an oracle rotation.
+/// Prevents quiet takeovers: even with admin key compromise, a 1-hour window
+/// gives operators and monitoring dashboards time to react.
+const MIN_ROTATION_DELAY_SECONDS: u64 = 3_600; // 1 hour
 
 const DEFAULT_BET_WINDOW_LEDGERS: u32 = 6;
 const DEFAULT_RUN_WINDOW_LEDGERS: u32 = 12;
@@ -327,7 +331,7 @@ impl VirtualTokenContract {
         admin.require_auth();
         Self::_ensure_not_paused(&env)?;
 
-        if expires_in_seconds < MIN_ROTATION_EXPIRY_SECONDS {
+        if expires_in_seconds < MIN_ROTATION_DELAY_SECONDS {
             return Err(ContractError::InvalidDuration);
         }
 
@@ -357,10 +361,17 @@ impl VirtualTokenContract {
 
     /// Accepts a pending oracle rotation proposal before expiry (any caller).
     ///
-    /// If the proposal has expired the call returns `RotationExpired` and the
+    /// **Security**: A mandatory `MIN_ROTATION_DELAY_SECONDS` (1 hour) must
+    /// elapse between proposal and acceptance. This prevents quiet one-block
+    /// takeovers — even if the admin key is compromised, the community has a
+    /// full hour to observe the proposal event and react before the oracle
+    /// actually changes.
+    ///
+    /// If the delay has not elapsed the call returns `RotationDelayNotElapsed`.
+    /// If the proposal has expired it returns `NoPendingRotation` and the
     /// stale proposal is removed after emitting `("oracle", "expired")`.
     /// On success the stored oracle address is updated and
-    /// `("oracle", "accept")` is emitted.
+    /// `("oracle", "accept")` is emitted with the previous and new addresses.
     pub fn accept_oracle_rotation(env: Env) -> Result<(), ContractError> {
         Self::_require_supported_schema(&env)?;
         Self::_ensure_not_paused(&env)?;
@@ -373,6 +384,24 @@ impl VirtualTokenContract {
             .ok_or(ContractError::NoPendingRotation)?;
 
         let current_ts = env.ledger().timestamp();
+
+        // Mandatory delay before acceptance (prevents quiet takeovers)
+        let earliest_accept = proposal
+            .proposed_at
+            .checked_add(MIN_ROTATION_DELAY_SECONDS)
+            .ok_or(ContractError::Overflow)?;
+        if current_ts < earliest_accept {
+            #[allow(deprecated)]
+            env.events().publish(
+                (symbol_short!("oracle"), symbol_short!("early")),
+                (
+                    proposal.new_oracle.clone(),
+                    current_ts,
+                    earliest_accept,
+                ),
+            );
+            return Err(ContractError::RotationDelayNotElapsed);
+        }
 
         if current_ts > proposal.expires_at {
             env.storage().persistent().remove(&key);

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -94,6 +94,8 @@ pub enum ContractError {
     MintLimitExceeded = 53,
     /// No pending oracle rotation proposal to accept or cancel
     NoPendingRotation = 54,
+    /// Oracle rotation delay has not elapsed yet (must wait MIN_ROTATION_DELAY_SECONDS)
+    RotationDelayNotElapsed = 55,
     /// Invalid archive retention limit
     InvalidArchiveRetention = 62,
     /// Commitment hash is malformed (e.g. the all-zero placeholder)

--- a/contracts/src/tests/rotation.rs
+++ b/contracts/src/tests/rotation.rs
@@ -285,3 +285,177 @@ fn test_propose_requires_admin_auth() {
     let result = client.try_propose_oracle_rotation(&new_oracle, &3600);
     assert!(result.is_err(), "non-admin should not be able to propose");
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Early-accept / delay tests (Issue #273)
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_accept_before_min_delay_fails() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let (_admin, _oracle, new_oracle) = init(&env, &client);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    // Propose with long expiry
+    client.propose_oracle_rotation(&new_oracle, &7200);
+
+    // Try to accept immediately — should fail (delay not elapsed)
+    let result = client.try_accept_oracle_rotation();
+    assert_eq!(result, Err(Ok(ContractError::RotationDelayNotElapsed)));
+
+    // Oracle should NOT have changed
+    let stored: Address = client.get_oracle().expect("oracle should still be set");
+    assert_ne!(stored, new_oracle, "oracle should not have been rotated early");
+
+    // Proposal should still exist
+    assert!(
+        client.get_oracle_rotation_proposal().is_some(),
+        "proposal should still exist after failed early accept"
+    );
+}
+
+#[test]
+fn test_accept_after_min_delay_succeeds() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let (_admin, _oracle, new_oracle) = init(&env, &client);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    client.propose_oracle_rotation(&new_oracle, &7200);
+
+    // Advance past the min delay (1 hour = 3600 seconds)
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000 + 3600 + 1; // 1 hour + 1 second
+    });
+
+    // Should succeed now
+    client.accept_oracle_rotation();
+
+    let stored: Address = client.get_oracle().expect("oracle should be set");
+    assert_eq!(stored, new_oracle, "oracle should have been rotated");
+
+    assert!(
+        client.get_oracle_rotation_proposal().is_none(),
+        "proposal should be removed after acceptance"
+    );
+}
+
+#[test]
+fn test_accept_exactly_at_min_delay_succeeds() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let (_admin, _oracle, new_oracle) = init(&env, &client);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    client.propose_oracle_rotation(&new_oracle, &7200);
+
+    // Advance exactly to the boundary (1000 + 3600 = 4600)
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000 + 3600; // exactly at min delay boundary
+    });
+
+    // Should succeed at exactly the boundary
+    client.accept_oracle_rotation();
+
+    let stored: Address = client.get_oracle().expect("oracle should be set");
+    assert_eq!(stored, new_oracle, "oracle should have been rotated at exact boundary");
+}
+
+#[test]
+fn test_early_accept_emits_oracle_early_event() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let (_admin, _oracle, new_oracle) = init(&env, &client);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    client.propose_oracle_rotation(&new_oracle, &7200);
+
+    let _ = client.try_accept_oracle_rotation();
+
+    let events = env.events().all();
+    assert!(
+        has_event_with_topic(&events, &env, symbol_short!("early")),
+        "early-accept attempt should emit (oracle, early) event"
+    );
+}
+
+#[test]
+fn test_accept_before_delay_fails_then_succeeds_after_delay() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let (_admin, oracle, new_oracle) = init(&env, &client);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 5000;
+    });
+
+    client.propose_oracle_rotation(&new_oracle, &7200);
+
+    // Try immediately — should fail
+    let result = client.try_accept_oracle_rotation();
+    assert_eq!(result, Err(Ok(ContractError::RotationDelayNotElapsed)));
+    assert_eq!(client.get_oracle().unwrap(), oracle);
+
+    // Try halfway through delay — should still fail
+    env.ledger().with_mut(|li| {
+        li.timestamp = 5000 + 1800; // 30 min
+    });
+    let result = client.try_accept_oracle_rotation();
+    assert_eq!(result, Err(Ok(ContractError::RotationDelayNotElapsed)));
+    assert_eq!(client.get_oracle().unwrap(), oracle);
+
+    // Advance past full delay — should succeed
+    env.ledger().with_mut(|li| {
+        li.timestamp = 5000 + 3601; // 1 hour + 1 second
+    });
+    client.accept_oracle_rotation();
+    assert_eq!(client.get_oracle().unwrap(), new_oracle);
+}
+
+#[test]
+fn test_expired_proposal_returns_expired_when_delay_passed() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let (_admin, _oracle, new_oracle) = init(&env, &client);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    // Expiry (3600) is exactly at the min delay boundary (also 3600).
+    // After 4000 seconds, the proposal is expired AND delay elapsed.
+    client.propose_oracle_rotation(&new_oracle, &3600);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000 + 4000; // expired
+    });
+
+    // Should fail with NoPendingRotation (expiry check wins)
+    let result = client.try_accept_oracle_rotation();
+    assert_eq!(result, Err(Ok(ContractError::NoPendingRotation)));
+}

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -292,6 +292,66 @@ Emitted when the oracle records an on-chain liveness heartbeat.
 | 0        | `timestamp` | `u64` | Unix epoch seconds when the heartbeat was recorded on-chain  |
 | 1        | `status`    | `u32` | Oracle status: `0` = active, `1` = degraded, `2` = offline  |
 
+---
+
+## Oracle rotation events (two-step with mandatory delay)
+
+Oracle rotation uses a two-step flow with a **mandatory 1-hour delay**
+(`MIN_ROTATION_DELAY_SECONDS = 3_600`) between proposal and acceptance.
+This prevents quiet takeovers — even with admin key compromise, operators
+have a full hour to observe the proposal and react.
+
+### `("oracle", "propose")`
+
+Emitted when the admin proposes a new oracle address with an expiry window.
+
+| Position | Field         | Type      | Description                                            |
+|----------|---------------|-----------|--------------------------------------------------------|
+| 0        | `new_oracle`  | `Address` | Proposed new oracle address                            |
+| 1        | `expires_at`  | `u64`     | Unix timestamp when the proposal expires               |
+
+### `("oracle", "accept")`
+
+Emitted when a pending rotation proposal is successfully accepted (after the
+mandatory delay has elapsed and before expiry).
+
+| Position | Field             | Type      | Description                               |
+|----------|-------------------|-----------|-------------------------------------------|
+| 0        | `previous_oracle` | `Address` | Oracle address before the rotation         |
+| 1        | `new_oracle`      | `Address` | New oracle address after the rotation      |
+
+### `("oracle", "cancel")`
+
+Emitted when the admin cancels a pending rotation proposal.
+
+| Position | Field         | Type      | Description                                      |
+|----------|---------------|-----------|--------------------------------------------------|
+| 0        | `new_oracle`  | `Address` | The proposed oracle address that was cancelled    |
+
+### `("oracle", "expired")`
+
+Emitted when an expired proposal is cleaned up (auto-clean in
+`get_oracle_rotation_proposal` or during `accept_oracle_rotation`).
+
+| Position | Field         | Type  | Description                                      |
+|----------|---------------|-------|--------------------------------------------------|
+| 0        | `new_oracle`  | `Address` | The proposed oracle address that expired       |
+| 1        | `proposed_at` | `u64` | Unix timestamp when the proposal was created      |
+| 2        | `expires_at`  | `u64` | Unix timestamp when the proposal expired          |
+
+### `("oracle", "early")`
+
+Emitted when an attempt to accept a rotation proposal is rejected because the
+mandatory delay (`MIN_ROTATION_DELAY_SECONDS`) has not yet elapsed.
+
+| Position | Field           | Type  | Description                                          |
+|----------|-----------------|-------|------------------------------------------------------|
+| 0        | `new_oracle`    | `Address` | The proposed oracle address                       |
+| 1        | `current_ts`    | `u64` | Current ledger timestamp at rejection time            |
+| 2        | `earliest_accept` | `u64` | Timestamp at which acceptance will be allowed       |
+
+---
+
 ### `("mode", "transition")`
 
 Emitted when the contract's emergency runtime mode is changed by the admin.

--- a/docs/ORACLE_OPERATOR_RUNBOOK.md
+++ b/docs/ORACLE_OPERATOR_RUNBOOK.md
@@ -388,6 +388,69 @@ Prevention:
 
 ---
 
+## 9. Oracle Rotation (Two-Step with Mandatory Delay)
+
+The oracle address can be rotated through a two-step process: first the admin
+proposes a new oracle, then **any caller** can accept the proposal after a
+**mandatory 1-hour delay** has elapsed. This delay prevents quiet one-block
+takeovers — even if the admin key is compromised, the community has a full hour
+to observe the `(oracle, propose)` event and react before the oracle actually
+changes.
+
+### 9.1 Rotation lifecycle
+
+```
+Admin proposes ──→ (1 hour delay) ──→ Anyone accepts ──→ Oracle rotated
+     │                                       │
+     └── Admin can cancel at any time ───────┘
+```
+
+### 9.2 Constants
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `MIN_ROTATION_DELAY_SECONDS` | 3 600 (1 hour) | Minimum time between proposal and acceptance |
+| `MIN_ROTATION_EXPIRY_SECONDS` | 60 (1 minute) | Minimum expiry window after delay |
+
+### 9.3 Entry points
+
+**`propose_oracle_rotation(new_oracle, expires_in_seconds)`** (admin only)
+- Proposes a new oracle address.
+- `expires_in_seconds` must be ≥ 3 600 (the mandatory delay).
+- Emits `(oracle, propose)`.
+
+**`accept_oracle_rotation()`** (any caller)
+- Accepts the pending proposal after the delay has elapsed.
+- Fails with `RotationDelayNotElapsed` if called too early.
+- Fails with `NoPendingRotation` if the proposal has expired.
+- Emits `(oracle, accept)` on success.
+
+**`cancel_oracle_rotation()`** (admin only)
+- Cancels a pending proposal at any time.
+- Emits `(oracle, cancel)`.
+
+### 9.4 Events
+
+| Event | Emitted when |
+|-------|-------------|
+| `(oracle, propose)` | Admin proposes a new oracle |
+| `(oracle, accept)` | Rotation is successfully accepted after delay |
+| `(oracle, cancel)` | Admin cancels a pending proposal |
+| `(oracle, expired)` | Proposal expires (auto-cleaned) |
+| `(oracle, early)` | Acceptance attempted before delay elapsed |
+
+### 9.5 Monitoring checklist
+
+Operators and monitoring dashboards should:
+1. Watch for `(oracle, propose)` events — these signal an impending rotation.
+2. If the proposed address is unexpected, escalate to the admin within the
+   1-hour delay window.
+3. Watch for `(oracle, early)` events — these indicate someone is trying to
+   bypass the delay.
+4. After `(oracle, accept)`, verify the new oracle by calling `get_oracle()`.
+
+---
+
 ## Related Documents
 
 | Document | Contents |


### PR DESCRIPTION
## Summary

Adds a mandatory 1-hour delay (`MIN_ROTATION_DELAY_SECONDS = 3_600`) between proposing and accepting an oracle rotation. Prevents quiet one-block takeovers — even with admin key compromise, the community has a full hour to observe the proposal event and react.

**Closes #273**

## Changes

### `contracts/src/contract.rs`
- Added `MIN_ROTATION_DELAY_SECONDS = 3_600` constant
- `propose_oracle_rotation`: enforces `expires_in_seconds >= MIN_ROTATION_DELAY_SECONDS` (prevents dead-on-arrival proposals)
- `accept_oracle_rotation`: new delay check rejects early acceptance with `RotationDelayNotElapsed`, emits `(oracle, early)` event on attempt

### `contracts/src/errors.rs`
- Added `RotationDelayNotElapsed = 55`

### `contracts/src/tests/rotation.rs` — 6 new tests
- `test_accept_before_min_delay_fails` — immediate accept rejected
- `test_accept_after_min_delay_succeeds` — accept after 1h+1s works
- `test_accept_exactly_at_min_delay_succeeds` — boundary condition works
- `test_early_accept_emits_oracle_early_event` — event emitted
- `test_accept_before_delay_fails_then_succeeds_after_delay` — retry lifecycle
- `test_expired_proposal_returns_expired_when_delay_passed` — expired takes priority

### Docs
- `docs/EVENT_SCHEMA.md`: documented all 5 oracle rotation events (propose, accept, cancel, expired, early)
- `docs/ORACLE_OPERATOR_RUNBOOK.md`: new Section 9 — Oracle Rotation with lifecycle, constants, entrypoints, events table, and monitoring checklist

### Files changed: 5 (+331 / -3)