### PR TITLE
feat: oracle heartbeat health gate with grace period and audited override (#264)

### DIFF
--- a/contracts/src/admin.rs
+++ b/contracts/src/admin.rs
@@ -4,7 +4,7 @@ use crate::common::{
     DEFAULT_BET_WINDOW_LEDGERS, DEFAULT_ORACLE_STALE_THRESHOLD, DEFAULT_RUN_WINDOW_LEDGERS,
 };
 use crate::errors::ContractError;
-use crate::types::{DataKey, OracleHeartbeatRecord, ProtocolHealthStatus, Round, RuntimeMode};
+use crate::types::{DataKey, HbGateConfig, HbGateKey, OracleHeartbeatRecord, ProtocolHealthStatus, Round, RuntimeMode};
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
 /// Initializes the contract with admin and oracle addresses (one-time only)
@@ -333,6 +333,119 @@ pub fn get_oracle_strict_mode(env: Env) -> bool {
     let key = DataKey::OracleStrictMode;
     _extend_persistent_ttl(&env, &key);
     env.storage().persistent().get(&key).unwrap_or(false)
+}
+
+/// Enables or disables strict mode for oracle heartbeat health at settlement (admin only, Issue #264).
+///
+/// When enabled, `resolve_round` will reject settlement if the oracle heartbeat is not live,
+/// unless an admin override is armed or the heartbeat is within the configured grace period.
+pub fn set_hb_strict_mode(env: Env, enabled: bool) -> Result<(), ContractError> {
+    _require_supported_schema(&env)?;
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::AdminNotSet)?;
+    admin.require_auth();
+    let mut config = _load_hb_config(&env);
+    config.strict_mode = enabled;
+    _save_hb_config(&env, &config);
+    Ok(())
+}
+
+/// Returns whether oracle heartbeat strict mode is enabled.
+pub fn get_hb_strict_mode(env: Env) -> bool {
+    _load_hb_config(&env).strict_mode
+}
+
+/// Arms a one-shot override to bypass the heartbeat health gate for the next settlement (admin only, Issue #264).
+///
+/// Consumed automatically when the next `resolve_round` call passes the heartbeat health gate
+/// while the override is armed. Does not persist across rounds.
+pub fn arm_hb_override(env: Env) -> Result<(), ContractError> {
+    let admin_key = DataKey::Admin;
+    _extend_persistent_ttl(&env, &admin_key);
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&admin_key)
+        .ok_or(ContractError::AdminNotSet)?;
+    admin.require_auth();
+    _ensure_not_paused(&env).inspect_err(|&e| {
+        _emit_action_rejected(&env, &admin, symbol_short!("arm_hovr"), e);
+    })?;
+
+    let mut config = _load_hb_config(&env);
+    config.override_armed = true;
+    _save_hb_config(&env, &config);
+    Ok(())
+}
+
+/// Returns whether the oracle heartbeat override is currently armed.
+pub fn get_hb_override_armed(env: Env) -> bool {
+    _load_hb_config(&env).override_armed
+}
+
+/// Sets the grace period in seconds between heartbeat staleness and settlement block (admin only, Issue #264).
+///
+/// When the oracle heartbeat is stale (past `OracleStaleThreshold`), the contract allows an additional
+/// `grace_seconds` window before the heartbeat health gate blocks settlement in strict mode.
+/// Default is 0 (no grace period).
+pub fn set_hb_grace_seconds(env: Env, seconds: u64) -> Result<(), ContractError> {
+    _require_supported_schema(&env)?;
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::AdminNotSet)?;
+    admin.require_auth();
+    let mut config = _load_hb_config(&env);
+    config.grace_seconds = seconds;
+    _save_hb_config(&env, &config);
+    Ok(())
+}
+
+/// Returns the configured heartbeat grace period in seconds (default 0).
+pub fn get_hb_grace_seconds(env: Env) -> u64 {
+    _load_hb_config(&env).grace_seconds
+}
+
+/// Consumes the heartbeat override if armed (called from settlement).
+/// Returns true if the override was consumed.
+pub fn _consume_hb_override(env: &Env) -> bool {
+    let config = _load_hb_config(env);
+    if config.override_armed {
+        let mut new_config = config.clone();
+        new_config.override_armed = false;
+        _save_hb_config(env, &new_config);
+        true
+    } else {
+        false
+    }
+}
+
+/// Loads the heartbeat gate config, returning defaults if unset.
+pub fn _load_hb_config(env: &Env) -> HbGateConfig {
+    let key = HbGateKey::Config;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, crate::common::TTL_BUMP_THRESHOLD, crate::common::TTL_BUMP_AMOUNT);
+    }
+    env.storage().persistent().get(&key).unwrap_or(HbGateConfig {
+        strict_mode: false,
+        override_armed: false,
+        grace_seconds: 0,
+    })
+}
+
+/// Saves the heartbeat gate config to persistent storage.
+pub fn _save_hb_config(env: &Env, config: &HbGateConfig) {
+    let key = HbGateKey::Config;
+    env.storage().persistent().set(&key, config);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, crate::common::TTL_BUMP_THRESHOLD, crate::common::TTL_BUMP_AMOUNT);
 }
 
 /// Records an oracle heartbeat (oracle only).

--- a/contracts/src/contract.rs
+++ b/contracts/src/contract.rs
@@ -186,6 +186,36 @@ impl VirtualTokenContract {
         admin::get_oracle_strict_mode(env)
     }
 
+    /// Enables or disables strict mode for oracle heartbeat health at settlement (admin only, Issue #264).
+    pub fn set_hb_strict_mode(env: Env, enabled: bool) -> Result<(), ContractError> {
+        admin::set_hb_strict_mode(env, enabled)
+    }
+
+    /// Returns whether oracle heartbeat strict mode is enabled (Issue #264).
+    pub fn get_hb_strict_mode(env: Env) -> bool {
+        admin::get_hb_strict_mode(env)
+    }
+
+    /// Arms a one-shot override to bypass the heartbeat health gate for the next settlement (admin only, Issue #264).
+    pub fn arm_hb_override(env: Env) -> Result<(), ContractError> {
+        admin::arm_hb_override(env)
+    }
+
+    /// Returns whether the oracle heartbeat override is currently armed (Issue #264).
+    pub fn get_hb_override_armed(env: Env) -> bool {
+        admin::get_hb_override_armed(env)
+    }
+
+    /// Sets the grace period in seconds between heartbeat staleness and settlement block (admin only, Issue #264).
+    pub fn set_hb_grace_seconds(env: Env, seconds: u64) -> Result<(), ContractError> {
+        admin::set_hb_grace_seconds(env, seconds)
+    }
+
+    /// Returns the configured heartbeat grace period in seconds (default 0, Issue #264).
+    pub fn get_hb_grace_seconds(env: Env) -> u64 {
+        admin::get_hb_grace_seconds(env)
+    }
+
     /// Records an oracle heartbeat (oracle only).
     pub fn update_oracle_heartbeat(env: Env, status: u32) -> Result<(), ContractError> {
         admin::update_oracle_heartbeat(env, status)

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -102,4 +102,6 @@ pub enum ContractError {
     InvalidSalt = 64,
     /// `create_next_from_template` called with no round template configured
     NoRoundTemplate = 65,
+    /// Oracle heartbeat is not live and strict mode blocks settlement (Issue #264)
+    OracleNotLive = 66,
 }

--- a/contracts/src/settlement.rs
+++ b/contracts/src/settlement.rs
@@ -7,9 +7,9 @@ use crate::common::{
 use crate::config::{_apply_protocol_fee_precision, _apply_protocol_fee_updown};
 use crate::errors::ContractError;
 use crate::types::{
-    ArchivedRoundSummary, BetSide, DataKey, OraclePayload, PrecisionCommitment,
-    PrecisionPrediction, Round, RoundArchiveStatus, RoundMode, UserOutcomeType, UserPosition,
-    UserRoundOutcome, UserStats,
+    ArchivedRoundSummary, BetSide, DataKey, HbGateConfig, OracleHeartbeatRecord,
+    OraclePayload, PrecisionCommitment, PrecisionPrediction, Round, RoundArchiveStatus,
+    RoundMode, UserOutcomeType, UserPosition, UserRoundOutcome, UserStats,
 };
 use soroban_sdk::{symbol_short, Address, Env, Map, Vec};
 
@@ -373,6 +373,42 @@ pub fn resolve_round(env: Env, payload: OraclePayload) -> Result<(), ContractErr
         return Err(ContractError::OracleNonceReused);
     }
     env.storage().persistent().set(&nonce_key, &true);
+
+    // ─── Oracle heartbeat health gate (Issue #264) ──────────────────────────
+    //
+    // When `HbGateConfig.strict_mode` is enabled, `resolve_round` verifies
+    // that the oracle heartbeat is live before allowing settlement.
+    let hb_config = crate::admin::_load_hb_config(&env);
+
+    if hb_config.strict_mode {
+        let hb_blocked = _check_heartbeat_health_blocked(&env, &hb_config);
+
+        if hb_blocked {
+            if hb_config.override_armed {
+                // Consume the one-shot override
+                crate::admin::_consume_hb_override(&env);
+
+                #[allow(deprecated)]
+                env.events().publish(
+                    (symbol_short!("oracle"), symbol_short!("hoverride")),
+                    (round.round_id,),
+                );
+            } else {
+                #[allow(deprecated)]
+                env.events().publish(
+                    (symbol_short!("oracle"), symbol_short!("hblocked")),
+                    (round.round_id,),
+                );
+                _emit_action_rejected(
+                    &env,
+                    &oracle,
+                    symbol_short!("resolve"),
+                    ContractError::OracleNotLive,
+                );
+                return Err(ContractError::OracleNotLive);
+            }
+        }
+    }
 
     let current_ledger = env.ledger().sequence();
     if current_ledger < round.end_ledger {
@@ -1379,6 +1415,50 @@ pub fn _refund_under_threshold(
         .persistent()
         .remove(&DataKey::PrecisionPositions);
     Ok(())
+}
+
+/// Returns `true` if the oracle heartbeat health gate should block settlement (Issue #264).
+///
+/// Checks:
+/// 1. No heartbeat recorded → blocked
+/// 2. Status = 2 (offline) → blocked
+/// 3. Heartbeat stale beyond (threshold + grace) → blocked
+/// 4. Otherwise → not blocked (allowed)
+pub fn _check_heartbeat_health_blocked(env: &Env, config: &HbGateConfig) -> bool {
+    use crate::common::DEFAULT_ORACLE_STALE_THRESHOLD;
+
+    let heartbeat_key = DataKey::OracleHeartbeat;
+    _extend_persistent_ttl(env, &heartbeat_key);
+    let record: OracleHeartbeatRecord =
+        match env.storage().persistent().get(&heartbeat_key) {
+            Some(r) => r,
+            None => return true, // No heartbeat → blocked
+        };
+
+    // Offline status always blocks
+    if record.status == 2 {
+        return true;
+    }
+
+    // Check staleness with grace period
+    let threshold_key = DataKey::OracleStaleThreshold;
+    _extend_persistent_ttl(env, &threshold_key);
+    let threshold: u64 = env
+        .storage()
+        .persistent()
+        .get(&threshold_key)
+        .unwrap_or(DEFAULT_ORACLE_STALE_THRESHOLD);
+
+    let grace: u64 = config.grace_seconds;
+
+    let current_time = env.ledger().timestamp();
+    let deadline = record
+        .timestamp
+        .saturating_add(threshold)
+        .saturating_add(grace);
+
+    // Blocked if past the stale threshold + grace period
+    current_time > deadline
 }
 
 pub fn _update_stats_win(env: &Env, user: Address) -> Result<(), ContractError> {

--- a/contracts/src/tests/security.rs
+++ b/contracts/src/tests/security.rs
@@ -1221,6 +1221,604 @@ fn test_missing_confidence_rejected_in_strict_mode() {
     assert_eq!(result, Err(Ok(ContractError::InvalidPrice)));
 }
 
+// ── Oracle heartbeat health gate tests (Issue #264) ──────────────────────────
+
+/// Helper: create a round with oracle heartbeat, advance to resolvable state.
+fn _setup_heartbeat_gate_test(
+    env: &Env,
+    client: &VirtualTokenContractClient,
+    heartbeat_timestamp: u64,
+    heartbeat_status: u32,
+) {
+    env.ledger().with_mut(|li| {
+        li.timestamp = heartbeat_timestamp;
+    });
+    client.update_oracle_heartbeat(&heartbeat_status);
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12; // past end_ledger
+        li.timestamp = heartbeat_timestamp + 100; // within threshold
+    });
+}
+
+#[test]
+fn test_heartbeat_gate_strict_off_allows_settlement_even_when_stale() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.create_round(&1_0000000, &None);
+
+    // Heartbeat at t=0, status active
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Advance past end_ledger, but strict mode is OFF (default)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 4000; // 4000s > 3600s stale threshold
+    });
+
+    // Should still resolve — strict mode is off
+    client.resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(client.get_active_round(), None);
+}
+
+#[test]
+fn test_heartbeat_gate_strict_on_blocks_when_stale_past_grace() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // Heartbeat at t=0, active
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Advance past stale threshold (3600s) + grace (default 0)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 4000;
+    });
+
+    let result = client.try_resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(result, Err(Ok(ContractError::OracleNotLive)));
+}
+
+#[test]
+fn test_heartbeat_gate_strict_on_allows_when_live() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // Heartbeat at t=100, active
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Advance to resolvable, timestamp within threshold
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 200;
+    });
+
+    client.resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(client.get_active_round(), None);
+}
+
+#[test]
+fn test_heartbeat_gate_blocks_offline_status_in_strict_mode() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // Heartbeat at t=0, offline (status=2)
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&2u32);
+
+    // Advance to resolvable (within threshold, but offline always blocks)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 10;
+    });
+
+    let result = client.try_resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(result, Err(Ok(ContractError::OracleNotLive)));
+}
+
+#[test]
+fn test_heartbeat_gate_blocks_no_heartbeat_in_strict_mode() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // No heartbeat recorded at all
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 100;
+    });
+
+    let result = client.try_resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(result, Err(Ok(ContractError::OracleNotLive)));
+}
+
+#[test]
+fn test_heartbeat_gate_override_bypasses_block_and_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // No heartbeat at all — would normally block
+    client.arm_hb_override();
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 100;
+    });
+
+    client.resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+
+    assert_eq!(client.get_active_round(), None);
+
+    // Verify override event emitted
+    let events = env.events().all();
+    let override_event = events.iter().find(|e| {
+        let (_contract, topics, _data) = e;
+        topics.len() == 2
+            && topics.get(0).unwrap().try_into_val(&env) == Ok(symbol_short!("oracle"))
+            && topics.get(1).unwrap().try_into_val(&env) == Ok(symbol_short!("hoverride"))
+    });
+    assert!(override_event.is_some(), "hoverride event must be emitted");
+
+    // Override is one-shot — must be consumed
+    env.as_contract(&contract_id, || {
+        let armed: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HbOverride)
+            .unwrap_or(false);
+        assert!(!armed, "heartbeat override must be cleared after use");
+    });
+}
+
+#[test]
+fn test_heartbeat_gate_override_is_one_shot() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+
+    // First round: arm override, resolve (consumes override)
+    client.create_round(&1_0000000, &None);
+    client.arm_hb_override();
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 100;
+    });
+    client.resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+
+    // Second round: no heartbeat, no override — should block
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 20;
+        li.timestamp = 200;
+    });
+    client.create_round(&1_0000000, &None);
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 32;
+        li.timestamp = 300;
+    });
+
+    let result = client.try_resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(result, Err(Ok(ContractError::OracleNotLive)));
+}
+
+#[test]
+fn test_heartbeat_gate_grace_period_allows_stale_within_grace() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    // Set grace period to 600s (10 minutes)
+    client.set_hb_grace_seconds(&600u64);
+
+    client.create_round(&1_0000000, &None);
+
+    // Heartbeat at t=0, active
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Advance past stale threshold (3600s) but within grace (3600+600=4200)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 4000; // 4000 < 4200, within grace
+    });
+
+    // Should resolve — within grace period
+    client.resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(client.get_active_round(), None);
+}
+
+#[test]
+fn test_heartbeat_gate_grace_period_blocks_after_grace_expires() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.set_hb_grace_seconds(&600u64);
+
+    client.create_round(&1_0000000, &None);
+
+    // Heartbeat at t=0, active
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&0u32);
+
+    // Advance past stale threshold + grace (3600 + 600 = 4200)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 4300; // 4300 > 4200, beyond grace
+    });
+
+    let result = client.try_resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(result, Err(Ok(ContractError::OracleNotLive)));
+}
+
+#[test]
+fn test_heartbeat_gate_degraded_status_allowed_when_current() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // Heartbeat at t=100, degraded (status=1)
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+    client.update_oracle_heartbeat(&1u32);
+
+    // Resolve within threshold
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 200;
+    });
+
+    // Degraded but current — should be allowed
+    client.resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(client.get_active_round(), None);
+}
+
+#[test]
+fn test_heartbeat_gate_degraded_stale_past_grace_blocked() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // Degraded heartbeat at t=0
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+    client.update_oracle_heartbeat(&1u32);
+
+    // Advance past stale threshold (no grace configured)
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 4000;
+    });
+
+    let result = client.try_resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+    assert_eq!(result, Err(Ok(ContractError::OracleNotLive)));
+}
+
+#[test]
+fn test_heartbeat_gate_hblocked_event_emitted() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin, &oracle);
+    client.set_hb_strict_mode(&true);
+    client.create_round(&1_0000000, &None);
+
+    // No heartbeat at all
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 12;
+        li.timestamp = 100;
+    });
+
+    let _ = client.try_resolve_round(&OraclePayload {
+        price: 1_2000000,
+        timestamp: env.ledger().timestamp(),
+        round_id: 0,
+        nonce: 1u64,
+        network_id: env.ledger().network_id(),
+        contract_addr: contract_id.clone(),
+        confidence: None,
+    });
+
+    let events = env.events().all();
+    let blocked_event = events.iter().find(|e| {
+        let (_contract, topics, _data) = e;
+        topics.len() == 2
+            && topics.get(0).unwrap().try_into_val(&env) == Ok(symbol_short!("oracle"))
+            && topics.get(1).unwrap().try_into_val(&env) == Ok(symbol_short!("hblocked"))
+    });
+    assert!(blocked_event.is_some(), "hblocked event must be emitted");
+}
+
+#[test]
+fn test_heartbeat_gate_arm_override_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize",
+            args: (&admin, &oracle).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize(&admin, &oracle);
+
+    // No auth — should fail
+    let result = client.try_arm_hb_override();
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_heartbeat_gate_set_strict_mode_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize",
+            args: (&admin, &oracle).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize(&admin, &oracle);
+
+    // No auth — should fail
+    let result = client.try_set_hb_strict_mode(&true);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_heartbeat_gate_getters_return_defaults() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    // Default values: strict mode OFF, override not armed, grace 0
+    assert!(!client.get_hb_strict_mode());
+    assert!(!client.get_hb_override_armed());
+    assert_eq!(client.get_hb_grace_seconds(), 0);
+}
+
+#[test]
+fn test_heartbeat_gate_set_and_get_grace_seconds() {
+    let env = Env::default();
+    let contract_id = env.register(VirtualTokenContract, ());
+    let client = VirtualTokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle);
+
+    client.set_hb_grace_seconds(&300u64);
+    assert_eq!(client.get_hb_grace_seconds(), 300);
+
+    client.set_hb_grace_seconds(&0u64);
+    assert_eq!(client.get_hb_grace_seconds(), 0);
+}
+
 #[test]
 fn test_no_confidence_check_when_threshold_unset() {
     let env = Env::default();

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -291,6 +291,22 @@ pub struct OracleHeartbeatRecord {
     pub status: u32,
 }
 
+/// Heartbeat health gate configuration (Issue #264).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct HbGateConfig {
+    pub strict_mode: bool,
+    pub override_armed: bool,
+    pub grace_seconds: u64,
+}
+
+/// Storage key for heartbeat gate config (separate from DataKey to stay within variant limits, Issue #264).
+#[contracttype]
+#[derive(Clone)]
+pub enum HbGateKey {
+    Config,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Round {

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -481,6 +481,37 @@ ended season are never deleted and remain independently queryable.
 
 ---
 
+## `("oracle", "hblocked")` — Heartbeat health gate blocked settlement
+
+Emitted when `resolve_round` is blocked by the heartbeat health gate in strict mode
+(Issue #264). The round remains active; the oracle or admin must address the heartbeat
+state before retrying.
+
+| Position | Field       | Type   | Description                                    |
+|----------|-------------|--------|------------------------------------------------|
+| 0        | `round_id`  | `u64`  | Round id that was blocked from settlement       |
+
+**Topics**: `("oracle", "hblocked")`
+**Source contracts**: `VirtualTokenContract`
+**Emitted by**: `resolve_round` (heartbeat health gate, strict mode).
+
+---
+
+## `("oracle", "hoverride")` — Heartbeat health gate override consumed
+
+Emitted when the admin-armed heartbeat health override is consumed during
+`resolve_round`, allowing settlement to proceed past the gate (Issue #264).
+
+| Position | Field       | Type   | Description                                    |
+|----------|-------------|--------|------------------------------------------------|
+| 0        | `round_id`  | `u64`  | Round id for which the override was consumed    |
+
+**Topics**: `("oracle", "hoverride")`
+**Source contracts**: `VirtualTokenContract`
+**Emitted by**: `resolve_round` (heartbeat health gate override path).
+
+---
+
 ---
 
 ## Field units quick reference

--- a/docs/ORACLE_OPERATOR_RUNBOOK.md
+++ b/docs/ORACLE_OPERATOR_RUNBOOK.md
@@ -188,6 +188,11 @@ prove liveness.
 `is_oracle_live()` returns `false` if no heartbeat exists, status is `2`, or the
 heartbeat is older than the threshold.
 
+**Heartbeat health gate (strict mode, Issue #264):** When `HbGateConfig.strict_mode`
+is enabled by the admin, `resolve_round` blocks settlement if the oracle heartbeat
+is not live. An admin-armed one-shot override (`arm_hb_override`) or a configured
+grace period (`HbGateConfig.grace_seconds`) can allow settlement through the gate.
+
 **Recommended interval:** every 15–30 minutes for a 1-hour threshold.
 
 ---

--- a/docs/WALLET_ERROR_GUIDE.md
+++ b/docs/WALLET_ERROR_GUIDE.md
@@ -39,9 +39,8 @@ This guide maps each smart‑contract error defined in `contracts/src/errors.rs`
 | `0x20` | 32 | StartPriceTooHigh | Start price exceeds the maximum allowed value | "Start price too high."
 | `0x21` | 33 | OracleNonceReused | Oracle payload nonce was already consumed for this round (replay) | "Oracle nonce reused."
 | `0x22` | 34 | InsufficientParticipants | Round has fewer participants than the configured minimum for competitive settlement | "Insufficient participants."
-| `0x23` | 35 | InvalidMinParticipants | Minimum participants value is out of valid range (must be 1–10000) | "Invalid min participants."
-| `0x24` | 36 | InvalidOracleStatus | Oracle heartbeat status is out of range (must be 0, 1, or 2) | "Invalid oracle status."
-| `0x25` | 37 | InvalidStaleThreshold | Oracle stale threshold is out of valid range (must be 60–86400 seconds) | "Invalid stale threshold."
+| `0x23` | 35 | InvalidMinParticipants | Minimum participants value is out of valid range (must be 1–10000) | "Invalid min participants."| `0x24` | 36 | InvalidOracleStatus | Oracle heartbeat status is out of range (must be 0, 1, or 2) | "Invalid oracle status." |
+| `0x42` | 66 | OracleNotLive | Oracle heartbeat is not live and strict mode blocks settlement | "Oracle heartbeat not live." | `0x25` | 37 | InvalidStaleThreshold | Oracle stale threshold is out of valid range (must be 60–86400 seconds) | "Invalid stale threshold."
 | `0x26` | 38 | InvalidOracleDeviationBps | Oracle max deviation bps is invalid (must be > 0) | "Invalid oracle deviation BPS."
 | `0x27` | 39 | OracleDeviationExceeded | Oracle final price deviates beyond configured threshold | "Oracle deviation exceeded."
 | `0x28` | 40 | UnsupportedSchemaVersion | Stored schema version is unknown or unsupported by this contract build | "Unsupported schema version."


### PR DESCRIPTION
## Summary

Closes #264

Enforce oracle heartbeat liveness at settlement with a configurable strict-mode gate, grace period, and one-shot admin override.

## Allow/Deny Matrix

| Heartbeat state | Override | Strict mode OFF | Strict mode ON |
|---|---|---|---|
| Active (0), current | N/A | ALLOW | ALLOW |
| Active (0), stale | Armed | ALLOW | ALLOW |
| Active (0), stale | Not | ALLOW | BLOCK (past grace) |
| Degraded (1), current | N/A | ALLOW | ALLOW |
| Degraded (1), stale | Armed | ALLOW | ALLOW |
| Degraded (1), stale | Not | ALLOW | BLOCK (past grace) |
| Offline (2) | Armed | ALLOW | ALLOW |
| Offline (2) | Not | ALLOW | BLOCK |
| No heartbeat | Armed | ALLOW | ALLOW |
| No heartbeat | Not | ALLOW | BLOCK |

## New Types & Storage
- `HbGateConfig` struct: `strict_mode`, `override_armed`, `grace_seconds`
- `HbGateKey` enum (separate from DataKey to stay within variant limits)
- `OracleNotLive = 66` error variant

## New Admin Functions
- `set_hb_strict_mode` / `get_hb_strict_mode`
- `arm_hb_override` / `get_hb_override_armed`
- `set_hb_grace_seconds` / `get_hb_grace_seconds`

## Settlement Gate
- Heartbeat health check in `resolve_round()` after nonce verification
- Grace period: `heartbeat.timestamp + stale_threshold + grace_seconds`
- One-shot override consumed on use
- Events: `oracle:hblocked` (blocked), `oracle:hoverride` (override consumed)

## Tests (18 branch tests)
- Strict mode off allows settlement (baseline)
- Strict mode on blocks stale/offline/no-heartbeat
- Override bypasses block, is one-shot, emits event
- Grace period allows within window, blocks after expiry
- Degraded status allowed when current
- Auth required for admin actions
- Default getters return correct values

## Documentation
- `docs/EVENT_SCHEMA.md`: oracle:hblocked, oracle:hoverride
- `docs/ORACLE_OPERATOR_RUNBOOK.md`: Heartbeat health gate section
- `docs/WALLET_ERROR_GUIDE.md`: OracleNotLive (66)

## Files changed
- `contracts/src/types.rs` — HbGateConfig struct, HbGateKey enum
- `contracts/src/errors.rs` — OracleNotLive = 66
- `contracts/src/admin.rs` — 6 admin functions + helpers
- `contracts/src/settlement.rs` — Heartbeat health gate in resolve_round()
- `contracts/src/contract.rs` — Contract method wiring
- `contracts/src/tests/security.rs` — 18 comprehensive branch tests
- `docs/EVENT_SCHEMA.md` — New event types
- `docs/ORACLE_OPERATOR_RUNBOOK.md` — Gate documentation
- `docs/WALLET_ERROR_GUIDE.md` — Error code 66
