### PR TITLE
docs: add user docs for precision commit-reveal flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ This ensures:
 - ✅ **Simple & predictable** - First predictor gets the remainder
 - ✅ **Fair distribution** - Close to equal split, minimal advantage
 
+### Precision Commit-Reveal Flow
+
+To prevent front-running and copy-trading, Precision rounds support a two-step commit-reveal flow:
+1. **Commit**: Users submit a SHA-256 hash of their `predicted_price` and a `salt`. This locks their stake without revealing the guess. The commitment hash must be valid (not all-zeros).
+2. **Reveal**: During the reveal window, users submit the plaintext `predicted_price` and `salt`. The contract verifies the hash and enforces minimum salt entropy (to prevent trivial grinding).
+
+**Unrevealed Policy**:
+- **Anti-Griefing**: If at least one prediction is revealed (or placed directly), any unrevealed commitments are forfeited to the pot and count as losers.
+- **Conservation**: If *nobody* reveals in the round, all committed stakes are fully refunded to the users.
+
 ### Oracle Operator Runbook
 
 Oracle mistakes are a top incident source. See


### PR DESCRIPTION
## 🎯 Description

Fixes #282

This PR completes the v2 commit-reveal rollout for Precision mode and formally closes out the remaining acceptance criteria for the unrevealed policy and format checks.

### 🛡️ What's Changed
- **User Documentation (New in this PR)**: Added the "Precision Commit-Reveal Flow" section to `README.md` to clearly explain the user-facing mechanics, anti-griefing rules, and the conservation policy. 
- **Implementation Status (Previously Merged)**: The core implementation requirements for this issue have already been merged into `main` and are fully active:
  - *Format Checks*: Enforces `is_zero_bytes32` validation during `commit_prediction` to reject placeholder/empty commits early. 
  - *Salt Entropy Checks*: Enforces `salt_has_minimum_entropy` during `reveal_prediction` to block weak/grindable salts.
  - *Unrevealed Policy & Conservation*: 
    - Anti-Griefing: Unrevealed commitments are deterministically forfeited to the pot if anyone successfully reveals.
    - Conservation: All committed stakes are refunded if nobody reveals.
  - *Testing Coverage*: The `commit_reveal_e2e.rs` and `conservation.rs` integration tests currently verify the all-unrevealed refund path and the mixed-reveal forfeit path.

### 🧪 Verification
- All `cargo test` cases pass, verifying that the existing protections remain intact.
- Locally verified that the newly added documentation renders correctly and adheres to existing style guides.
